### PR TITLE
Added simple example for partial mocking

### DIFF
--- a/examples/DocumentationExamples/src/main/java/powermock/examples/partialmocking/EntityManager.java
+++ b/examples/DocumentationExamples/src/main/java/powermock/examples/partialmocking/EntityManager.java
@@ -1,0 +1,10 @@
+package powermock.examples.partialmocking;
+
+/**
+ * Created by Katharina Laube on 08.09.2014.
+ */
+public class EntityManager {
+    public void persist(Status status) {
+        // persist status
+    }
+}

--- a/examples/DocumentationExamples/src/main/java/powermock/examples/partialmocking/Status.java
+++ b/examples/DocumentationExamples/src/main/java/powermock/examples/partialmocking/Status.java
@@ -1,0 +1,7 @@
+package powermock.examples.partialmocking;
+
+/**
+ * Created by Katharina Laube on 08.09.2014.
+ */
+public class Status {
+}

--- a/examples/DocumentationExamples/src/main/java/powermock/examples/partialmocking/StatusSender.java
+++ b/examples/DocumentationExamples/src/main/java/powermock/examples/partialmocking/StatusSender.java
@@ -1,0 +1,24 @@
+package powermock.examples.partialmocking;
+
+/**
+ * Used to demonstrate PowerMock's ability to partial mock method calls.
+ *
+ * Created by Katharina Laube on 08.09.2014.
+ */
+public class StatusSender {
+
+    EntityManager entityManager = new EntityManager();
+
+    public boolean handleStatus(Status status){
+
+        entityManager.persist(status);
+
+        return sendStatus(status);
+    }
+
+    public boolean sendStatus(Status status){
+        // code that will not be tested with handleStatus method
+        // (i.e. send status via a topic)
+        return false;
+    }
+}

--- a/examples/DocumentationExamples/src/test/java/powermock/examples/partialmocking/StatusSenderTest.java
+++ b/examples/DocumentationExamples/src/test/java/powermock/examples/partialmocking/StatusSenderTest.java
@@ -1,0 +1,51 @@
+package powermock.examples.partialmocking;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.expect;
+import static org.powermock.api.easymock.PowerMock.*;
+
+/**
+ * Used to demonstrate PowerMock's ability to partial mock method calls.
+ * Simple exmaple without private method mocking.
+ *
+ * Created by Katharina Laube on 08.09.2014.
+ */
+public class StatusSenderTest {
+
+    private StatusSender tested;
+    private EntityManager entityManager;
+
+    @Before
+    public void setUp() throws Exception {
+
+        /* Mock only the sendStatus method.
+           (This mock creation should be moved to the test method,
+           when method sendStatus is tested as well.)
+         */
+        tested = createPartialMock(StatusSender.class, "sendStatus");
+
+        // Mock all methods of entityManager
+        entityManager = createMock(EntityManager.class);
+        tested.entityManager = entityManager;
+    }
+
+    @Test
+    public void testHandleStatus() throws Exception {
+        Status status = new Status();
+
+        // expect call of void method from EntityManager
+        entityManager.persist(status);
+
+        /* expect call of another method in the tested class
+           which will be tested separately. */
+        expect(tested.sendStatus(status)).andReturn(true);
+
+        replayAll();
+
+        tested.handleStatus(status);
+
+        verifyAll();
+    }
+}


### PR DESCRIPTION
On the wikipage https://code.google.com/p/powermock/wiki/MockPartial is the example missing. That's why I added a simple example for partial mocking (without private method mocking) for EasyMock extension.
