### PR TITLE
#698 Throw StackOverflowError when child method invoke twice parent method using PowerMock Mockito

### DIFF
--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/Child.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/Child.java
@@ -1,0 +1,13 @@
+package samples.powermockito.junit4.bugs.github698;
+
+class Child extends Parent {
+
+    @Override
+    public String print() {
+        String string = "";
+        string += super.print();
+        string += "Child";
+        string += super.print();
+        return string;
+    }
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/GitHub698Test.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/GitHub698Test.java
@@ -1,0 +1,24 @@
+package samples.powermockito.junit4.bugs.github698;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
+import static org.powermock.api.support.membermodification.MemberModifier.suppress;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Parent.class)
+public class GitHub698Test {
+    @Test
+    public void shouldSuppressBothCallToParentClasses() {
+        suppress(method(Parent.class));
+        Child child = spy(new Child());
+
+        assertThat(child.print()).isEqualTo("nullChildnull");
+    }
+}

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/Parent.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/Parent.java
@@ -1,0 +1,9 @@
+package samples.powermockito.junit4.bugs.github698;
+
+
+public class Parent {
+    public String print() {
+        return "parent";
+    }
+}
+

--- a/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/package-info.java
+++ b/modules/module-test/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github698/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Throw StackOverflowError when child method invoke twice parent method using PowerMock Mockito
+ * https://github.com/jayway/powermock/issues/698
+ */
+package samples.powermockito.junit4.bugs.github698;


### PR DESCRIPTION
Add tests to verify issue. 
