### PR TITLE
Issue #763: Fixing bug matching constructor with whenNew when first or last param is null.

### DIFF
--- a/tests/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/parameterized/WhenNewTest.java
+++ b/tests/mockito/junit4-delegate/src/test/java/powermock/modules/test/mockito/junit4/delegate/parameterized/WhenNewTest.java
@@ -16,6 +16,7 @@
 package powermock.modules.test.mockito.junit4.delegate.parameterized;
 
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import samples.classwithinnermembers.ClassWithInnerMembers;
 import samples.expectnew.ExpectNewDemo;
 import samples.newmocking.MyClass;
 
@@ -33,7 +34,8 @@ import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import powermock.modules.test.mockito.junit4.delegate.WhenNewCaseMethod;
 import samples.powermockito.junit4.whennew.WhenNewCases;
 
-@PrepareForTest({MyClass.class, ExpectNewDemo.class, DataInputStream.class, WhenNewCases.class})
+@PrepareForTest({MyClass.class, ExpectNewDemo.class, ClassWithInnerMembers.class, DataInputStream.class,
+        WhenNewCases.class})
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(Parameterized.class)
 public class WhenNewTest {

--- a/tests/mockito/junit4-rule-xstream/src/test/java/samples/powermockito/junit4/rule/xstream/WhenNewTest.java
+++ b/tests/mockito/junit4-rule-xstream/src/test/java/samples/powermockito/junit4/rule/xstream/WhenNewTest.java
@@ -15,9 +15,12 @@
  */
 package samples.powermockito.junit4.rule.xstream;
 
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.powermock.modules.junit4.rule.PowerMockRule;
 import samples.powermockito.junit4.whennew.WhenNewCases;
+
 
 /**
  * Test class to demonstrate new instance mocking using whenConstructionOf(..).
@@ -25,7 +28,24 @@ import samples.powermockito.junit4.whennew.WhenNewCases;
  */
 @SuppressWarnings("PrimitiveArrayArgumentToVariableArgMethod")
 public class WhenNewTest extends WhenNewCases{
-	@Rule
-	public PowerMockRule powerMockRule = new PowerMockRule();
+
+    @Rule
+    public PowerMockRule powerMockRule = new PowerMockRule();
+
+    @Ignore("Test case fails only for xstream with MockitoException: Mockito cannot mock this class: " +
+            "class samples.classwithinnermembers.ClassWithInnerMembers$1MyLocalClass")
+    @Test
+    @Override
+    public void testLocalClassMockingWorksWithNoConstructorArguments() throws Exception {
+        super.testLocalClassMockingWorksWithNoConstructorArguments();
+    }
+
+    @Ignore("Test case fails only for xstream with MockitoException: Mockito cannot mock this class: " +
+            "class samples.classwithinnermembers.ClassWithInnerMembers$2MyLocalClass")
+    @Test
+    @Override
+    public void testLocalClassMockingWorksWithConstructorArguments() throws Exception {
+        super.testLocalClassMockingWorksWithConstructorArguments();
+    }
 
 }

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/whennew/WhenNewCases.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/whennew/WhenNewCases.java
@@ -17,15 +17,13 @@ package samples.powermockito.junit4.whennew;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.junit.rules.ExpectedException;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.powermock.reflect.Whitebox;
 import org.powermock.reflect.exceptions.ConstructorNotFoundException;
 import samples.Service;
+import samples.classwithinnermembers.ClassWithInnerMembers;
+import samples.classwithinnermembers.ClassWithInnerMembers.*;
 import samples.expectnew.CreationException;
 import samples.expectnew.ExpectNewDemo;
 import samples.expectnew.ExpectNewServiceUser;
@@ -52,16 +50,14 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.verifyNew;
-import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.powermock.api.mockito.PowerMockito.*;
 import static org.powermock.api.support.membermodification.MemberMatcher.constructor;
 
 /**
  * Test class to demonstrate new instance mocking using whenConstructionOf(..).
  */
-@PrepareForTest({MyClass.class, ExpectNewDemo.class, DataInputStream.class, WhenNewCases.class, Target.class})
+@PrepareForTest({MyClass.class, ExpectNewDemo.class, ClassWithInnerMembers.class, DataInputStream.class,
+        WhenNewCases.class, Target.class})
 public class WhenNewCases {
 
     public static final String TARGET_NAME = "MyTarget";
@@ -70,6 +66,196 @@ public class WhenNewCases {
     public static final int UNKNOWN_TARGET_ID = -11;
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testStaticMemberClassMockingWorksWithNoConstructorArguments() throws Exception {
+        Class<Object> innerClassType = Whitebox.getInnerClassType(ClassWithInnerMembers.class, "MyInnerClass");
+        Object mockMyInnerClass = mock(innerClassType);
+        whenNew(innerClassType).withNoArguments().thenReturn(mockMyInnerClass);
+        doReturn("something else").when(mockMyInnerClass, "doStuff");
+
+        assertEquals("something else", new ClassWithInnerMembers().getValue());
+    }
+
+    @Test
+    public void testStaticMemberClassMockingWorksWithConstructorArguments() throws Exception {
+        Class<Object> innerClassType = Whitebox.getInnerClassType(
+                ClassWithInnerMembers.class, "StaticInnerClassWithConstructorArgument");
+        Object mockMyInnerClass = mock(innerClassType);
+        whenNew(innerClassType).withArguments("value").thenReturn(mockMyInnerClass);
+        doReturn("something else").when(mockMyInnerClass, "doStuff");
+
+        assertEquals(
+                "something else", new ClassWithInnerMembers().getValueForStaticInnerClassWithConstructorArgument());
+    }
+
+    @Test
+    public void testLocalClassMockingWorksWithNoConstructorArguments() throws Exception {
+        Class<Object> innerClassType = Whitebox.getLocalClassType(ClassWithInnerMembers.class, 1, "MyLocalClass");
+        Object mockMyInnerClass = mock(innerClassType);
+        whenNew(innerClassType).withNoArguments().thenReturn(mockMyInnerClass);
+        doReturn("something else").when(mockMyInnerClass, "doStuff");
+
+        assertEquals("something else", new ClassWithInnerMembers().getLocalClassValue());
+    }
+
+    @Test
+    public void testLocalClassMockingWorksWithConstructorArguments() throws Exception {
+        Class<Object> innerClassType = Whitebox.getLocalClassType(ClassWithInnerMembers.class, 2, "MyLocalClass");
+        Object mockMyInnerClass = mock(innerClassType);
+        whenNew(innerClassType).withArguments("my value").thenReturn(mockMyInnerClass);
+        doReturn("something else").when(mockMyInnerClass, "doStuff");
+
+        assertEquals("something else", new ClassWithInnerMembers().getLocalClassValueWithArgument());
+    }
+
+    @Test
+    public void testNonStaticMemberClassMockingWorksWithArguments() throws Exception {
+        Class<Object> innerClassType = Whitebox.getInnerClassType(
+                ClassWithInnerMembers.class, "MyInnerClassWithConstructorArgument");
+        Object mockMyInnerClass = mock(innerClassType);
+        whenNew(innerClassType).withArguments("value").thenReturn(mockMyInnerClass);
+        doReturn("something else").when(mockMyInnerClass, "doStuff");
+
+        assertEquals("something else", new ClassWithInnerMembers().getValueForInnerClassWithConstructorArgument());
+    }
+
+    @Test
+    public void testNewInnerWithDiffParams() throws Exception {
+        ClassWithInnerMembers outerClass = new ClassWithInnerMembers();
+        MyInnerClassWithPrivateConstructorWithDiffMultArgs mockMyInnerClassWithPrivateConstructorWithDiffMultArgs
+                = mock(MyInnerClassWithPrivateConstructorWithDiffMultArgs.class);
+
+        whenNew(MyInnerClassWithPrivateConstructorWithDiffMultArgs.class)
+                .withArguments(null, 2, "3").thenReturn(mockMyInnerClassWithPrivateConstructorWithDiffMultArgs);
+
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPrivateConstructorWithDiffMultArgs,
+                outerClass.makeMyInnerClassWithPrivateConstructorWithDiffMultArgs(null, 2, "3"));
+    }
+
+    @Test
+    public void testNewInnerWithNoNullParams() throws Exception {
+        ClassWithInnerMembers outerClass = new ClassWithInnerMembers();
+        MyInnerClassWithPublicConstructorWithMultArgs mockMyInnerClassWithPublicConstructorWithMultArgs
+                = mock(MyInnerClassWithPublicConstructorWithMultArgs.class);
+        MyInnerClassWithProtectedConstructorWithMultArgs mockMyInnerClassWithProtectedConstructorWithMultArgs
+                = mock(MyInnerClassWithProtectedConstructorWithMultArgs.class);
+        MyInnerClassWithPackageConstructorWithMultArgs mockMyInnerClassWithPackageConstructorWithMultArgs
+                = mock(MyInnerClassWithPackageConstructorWithMultArgs.class);
+        MyInnerClassWithPrivateConstructorWithMultArgs mockMyInnerClassWithPrivateConstructorWithMultArgs
+                = mock(MyInnerClassWithPrivateConstructorWithMultArgs.class);
+
+        whenNew(MyInnerClassWithPublicConstructorWithMultArgs.class)
+                .withArguments("1", "2", "3").thenReturn(mockMyInnerClassWithPublicConstructorWithMultArgs);
+        whenNew(MyInnerClassWithProtectedConstructorWithMultArgs.class)
+                .withArguments("1", "2", "3").thenReturn(mockMyInnerClassWithProtectedConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPackageConstructorWithMultArgs.class)
+                .withArguments("1", "2", "3").thenReturn(mockMyInnerClassWithPackageConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPrivateConstructorWithMultArgs.class)
+                .withArguments("1", "2", "3").thenReturn(mockMyInnerClassWithPrivateConstructorWithMultArgs);
+
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPublicConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPublicConstructorWithMultArgs("1", "2", "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithProtectedConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithProtectedConstructorWithMultArgs("1", "2", "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPackageConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPackageConstructorWithMultArgs("1", "2", "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPrivateConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPrivateConstructorWithMultArgs("1", "2", "3"));
+    }
+
+    @Test
+    public void testNewInnerWithMiddleParamNull() throws Exception {
+        ClassWithInnerMembers outerClass = new ClassWithInnerMembers();
+        MyInnerClassWithPublicConstructorWithMultArgs mockMyInnerClassWithPublicConstructorWithMultArgs
+                = mock(MyInnerClassWithPublicConstructorWithMultArgs.class);
+        MyInnerClassWithProtectedConstructorWithMultArgs mockMyInnerClassWithProtectedConstructorWithMultArgs
+                = mock(MyInnerClassWithProtectedConstructorWithMultArgs.class);
+        MyInnerClassWithPackageConstructorWithMultArgs mockMyInnerClassWithPackageConstructorWithMultArgs
+                = mock(MyInnerClassWithPackageConstructorWithMultArgs.class);
+        MyInnerClassWithPrivateConstructorWithMultArgs mockMyInnerClassWithPrivateConstructorWithMultArgs
+                = mock(MyInnerClassWithPrivateConstructorWithMultArgs.class);
+
+        whenNew(MyInnerClassWithPublicConstructorWithMultArgs.class)
+                .withArguments("1", null, "3").thenReturn(mockMyInnerClassWithPublicConstructorWithMultArgs);
+        whenNew(MyInnerClassWithProtectedConstructorWithMultArgs.class)
+                .withArguments("1", null, "3").thenReturn(mockMyInnerClassWithProtectedConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPackageConstructorWithMultArgs.class)
+                .withArguments("1", null, "3").thenReturn(mockMyInnerClassWithPackageConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPrivateConstructorWithMultArgs.class)
+                .withArguments("1", null, "3").thenReturn(mockMyInnerClassWithPrivateConstructorWithMultArgs);
+
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPublicConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPublicConstructorWithMultArgs("1", null, "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithProtectedConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithProtectedConstructorWithMultArgs("1", null, "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPackageConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPackageConstructorWithMultArgs("1", null, "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPrivateConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPrivateConstructorWithMultArgs("1", null, "3"));
+    }
+
+    @Test
+    public void testNewInnerWithFirstParamNull() throws Exception {
+        ClassWithInnerMembers outerClass = new ClassWithInnerMembers();
+        MyInnerClassWithPublicConstructorWithMultArgs mockMyInnerClassWithPublicConstructorWithMultArgs
+                = mock(MyInnerClassWithPublicConstructorWithMultArgs.class);
+        MyInnerClassWithProtectedConstructorWithMultArgs mockMyInnerClassWithProtectedConstructorWithMultArgs
+                = mock(MyInnerClassWithProtectedConstructorWithMultArgs.class);
+        MyInnerClassWithPackageConstructorWithMultArgs mockMyInnerClassWithPackageConstructorWithMultArgs
+                = mock(MyInnerClassWithPackageConstructorWithMultArgs.class);
+        MyInnerClassWithPrivateConstructorWithMultArgs mockMyInnerClassWithPrivateConstructorWithMultArgs
+                = mock(MyInnerClassWithPrivateConstructorWithMultArgs.class);
+
+        whenNew(MyInnerClassWithPublicConstructorWithMultArgs.class)
+                .withArguments(null, "2", "3").thenReturn(mockMyInnerClassWithPublicConstructorWithMultArgs);
+        whenNew(MyInnerClassWithProtectedConstructorWithMultArgs.class)
+                .withArguments(null, "2", "3").thenReturn(mockMyInnerClassWithProtectedConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPackageConstructorWithMultArgs.class)
+                .withArguments(null, "2", "3").thenReturn(mockMyInnerClassWithPackageConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPrivateConstructorWithMultArgs.class)
+                .withArguments(null, "2", "3").thenReturn(mockMyInnerClassWithPrivateConstructorWithMultArgs);
+
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPublicConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPublicConstructorWithMultArgs(null, "2", "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithProtectedConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithProtectedConstructorWithMultArgs(null, "2", "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPackageConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPackageConstructorWithMultArgs(null, "2", "3"));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPrivateConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPrivateConstructorWithMultArgs(null, "2", "3"));
+    }
+
+    @Test
+    public void testNewInnerWithLastParamNull() throws Exception {
+        ClassWithInnerMembers outerClass = new ClassWithInnerMembers();
+        MyInnerClassWithPublicConstructorWithMultArgs mockMyInnerClassWithPublicConstructorWithMultArgs
+                = mock(MyInnerClassWithPublicConstructorWithMultArgs.class);
+        MyInnerClassWithProtectedConstructorWithMultArgs mockMyInnerClassWithProtectedConstructorWithMultArgs
+                = mock(MyInnerClassWithProtectedConstructorWithMultArgs.class);
+        MyInnerClassWithPackageConstructorWithMultArgs mockMyInnerClassWithPackageConstructorWithMultArgs
+                = mock(MyInnerClassWithPackageConstructorWithMultArgs.class);
+        MyInnerClassWithPrivateConstructorWithMultArgs mockMyInnerClassWithPrivateConstructorWithMultArgs
+                = mock(MyInnerClassWithPrivateConstructorWithMultArgs.class);
+
+        whenNew(MyInnerClassWithPublicConstructorWithMultArgs.class)
+                .withArguments("1", "2", null).thenReturn(mockMyInnerClassWithPublicConstructorWithMultArgs);
+        whenNew(MyInnerClassWithProtectedConstructorWithMultArgs.class)
+                .withArguments("1", "2", null).thenReturn(mockMyInnerClassWithProtectedConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPackageConstructorWithMultArgs.class)
+                .withArguments("1", "2", null).thenReturn(mockMyInnerClassWithPackageConstructorWithMultArgs);
+        whenNew(MyInnerClassWithPrivateConstructorWithMultArgs.class)
+                .withArguments("1", "2", null).thenReturn(mockMyInnerClassWithPrivateConstructorWithMultArgs);
+
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPublicConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPublicConstructorWithMultArgs("1", "2", null));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithProtectedConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithProtectedConstructorWithMultArgs("1", "2", null));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPackageConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPackageConstructorWithMultArgs("1", "2", null));
+        assertEquals("Expected and actual did not match", mockMyInnerClassWithPrivateConstructorWithMultArgs,
+                outerClass.makeMyInnerClassWithPrivateConstructorWithMultArgs("1", "2", null));
+    }
 
     @Test
     public void testNewWithCheckedException() throws Exception {

--- a/tests/utils/src/main/java/samples/classwithinnermembers/ClassWithInnerMembers.java
+++ b/tests/utils/src/main/java/samples/classwithinnermembers/ClassWithInnerMembers.java
@@ -20,96 +20,187 @@ package samples.classwithinnermembers;
  */
 public class ClassWithInnerMembers {
 
-	private interface InnerInterface {
-		String doStuff();
-	}
+    private interface InnerInterface {
+        String doStuff();
+    }
 
-	private static class MyInnerClass implements InnerInterface {
+    public static class MyInnerClassWithPrivateConstructorWithDiffMultArgs {
 
-		@Override
-		public String doStuff() {
-			return "member class";
-		}
-	}
+        private String mArg1;
+        private int mArg2;
+        private String mArg3;
 
-	private static class StaticInnerClassWithConstructorArgument implements InnerInterface {
+        private MyInnerClassWithPrivateConstructorWithDiffMultArgs(String arg1, int arg2, String arg3) {
+            mArg1 = arg1;
+            mArg2 = arg2;
+            mArg3 = arg3;
+        }
+    }
 
-		private final String value;
+    public MyInnerClassWithPrivateConstructorWithDiffMultArgs makeMyInnerClassWithPrivateConstructorWithDiffMultArgs(
+            String arg1, int arg2, String arg3) {
+        return new MyInnerClassWithPrivateConstructorWithDiffMultArgs(arg1, arg2, arg3);
+    }
 
-		public StaticInnerClassWithConstructorArgument(String value) {
-			this.value = value;
-		}
+    public static class MyInnerClassWithPrivateConstructorWithMultArgs {
 
-		@Override
-		public String doStuff() {
-			return value;
-		}
-	}
+        private String mArg1;
+        private String mArg2;
+        private String mArg3;
 
-	private class MyInnerClassWithConstructorArgument implements InnerInterface {
+        private MyInnerClassWithPrivateConstructorWithMultArgs(String arg1, String arg2, String arg3) {
+            mArg1 = arg1;
+            mArg2 = arg2;
+            mArg3 = arg3;
+        }
+    }
 
-		private final String value;
+    public MyInnerClassWithPrivateConstructorWithMultArgs makeMyInnerClassWithPrivateConstructorWithMultArgs(
+            String arg1, String arg2, String arg3) {
+        return new MyInnerClassWithPrivateConstructorWithMultArgs(arg1, arg2, arg3);
+    }
 
-		public MyInnerClassWithConstructorArgument(String value) {
-			this.value = value;
-		}
+    public static class MyInnerClassWithPublicConstructorWithMultArgs {
 
-		@Override
-		public String doStuff() {
-			return value;
-		}
-	}
+        private String mArg1;
+        private String mArg2;
+        private String mArg3;
 
-	public String getValue() {
-		return new MyInnerClass().doStuff();
-	}
+        private MyInnerClassWithPublicConstructorWithMultArgs(String arg1, String arg2, String arg3) {
+            mArg1 = arg1;
+            mArg2 = arg2;
+            mArg3 = arg3;
+        }
+    }
 
-	public String getValueForInnerClassWithConstructorArgument() {
-		return new MyInnerClassWithConstructorArgument("value").doStuff();
-	}
+    public MyInnerClassWithPublicConstructorWithMultArgs makeMyInnerClassWithPublicConstructorWithMultArgs(
+            String arg1, String arg2, String arg3) {
+        return new MyInnerClassWithPublicConstructorWithMultArgs(arg1, arg2, arg3);
+    }
 
-	public String getValueForStaticInnerClassWithConstructorArgument() {
-		return new StaticInnerClassWithConstructorArgument("value").doStuff();
-	}
+    public static class MyInnerClassWithPackageConstructorWithMultArgs {
 
-	public String getLocalClassValue() {
-		class MyLocalClass implements InnerInterface {
-			@Override
-			public String doStuff() {
-				return "local class";
-			}
-		}
+        private String mArg1;
+        private String mArg2;
+        private String mArg3;
 
-		return new MyLocalClass().doStuff();
-	}
+        MyInnerClassWithPackageConstructorWithMultArgs(String arg1, String arg2, String arg3) {
+            mArg1 = arg1;
+            mArg2 = arg2;
+            mArg3 = arg3;
+        }
+    }
 
-	public String getLocalClassValueWithArgument() {
-		class MyLocalClass implements InnerInterface {
+    public MyInnerClassWithPackageConstructorWithMultArgs makeMyInnerClassWithPackageConstructorWithMultArgs(
+            String arg1, String arg2, String arg3) {
+        return new MyInnerClassWithPackageConstructorWithMultArgs(arg1, arg2, arg3);
+    }
 
-			private final String value;
+    public static class MyInnerClassWithProtectedConstructorWithMultArgs {
 
-			public MyLocalClass(String value) {
-				this.value = value;
-			}
+        private String mArg1;
+        private String mArg2;
+        private String mArg3;
 
-			@Override
-			public String doStuff() {
-				return value;
-			}
-		}
+        MyInnerClassWithProtectedConstructorWithMultArgs(String arg1, String arg2, String arg3) {
+            mArg1 = arg1;
+            mArg2 = arg2;
+            mArg3 = arg3;
+        }
+    }
 
-		return new MyLocalClass("my value").doStuff();
-	}
+    public MyInnerClassWithProtectedConstructorWithMultArgs makeMyInnerClassWithProtectedConstructorWithMultArgs(
+            String arg1, String arg2, String arg3) {
+        return new MyInnerClassWithProtectedConstructorWithMultArgs(arg1, arg2, arg3);
+    }
 
-	public String getValueForAnonymousInnerClass() {
+    private static class MyInnerClass implements InnerInterface {
 
-		InnerInterface inner = new InnerInterface() {
-			@Override
-			public String doStuff() {
-				return "value";
-			}
-		};
+        @Override
+        public String doStuff() {
+            return "member class";
+        }
+    }
 
-		return inner.doStuff();
-	}
+    private static class StaticInnerClassWithConstructorArgument implements InnerInterface {
+
+        private final String value;
+
+        public StaticInnerClassWithConstructorArgument(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String doStuff() {
+            return value;
+        }
+    }
+
+    private class MyInnerClassWithConstructorArgument implements InnerInterface {
+
+        private final String value;
+
+        public MyInnerClassWithConstructorArgument(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String doStuff() {
+            return value;
+        }
+    }
+
+    public String getValue() {
+        return new MyInnerClass().doStuff();
+    }
+
+    public String getValueForInnerClassWithConstructorArgument() {
+        return new MyInnerClassWithConstructorArgument("value").doStuff();
+    }
+
+    public String getValueForStaticInnerClassWithConstructorArgument() {
+        return new StaticInnerClassWithConstructorArgument("value").doStuff();
+    }
+
+    public String getLocalClassValue() {
+        class MyLocalClass implements InnerInterface {
+            @Override
+            public String doStuff() {
+                return "local class";
+            }
+        }
+
+        return new MyLocalClass().doStuff();
+    }
+
+    public String getLocalClassValueWithArgument() {
+        class MyLocalClass implements InnerInterface {
+
+            private final String value;
+
+            public MyLocalClass(String value) {
+                this.value = value;
+            }
+
+            @Override
+            public String doStuff() {
+                return value;
+            }
+        }
+
+        return new MyLocalClass("my value").doStuff();
+    }
+
+    public String getValueForAnonymousInnerClass() {
+
+        InnerInterface inner = new InnerInterface() {
+
+            @Override
+            public String doStuff() {
+                return "value";
+            }
+        };
+
+        return inner.doStuff();
+    }
 }


### PR DESCRIPTION
resolves issue #763 
 - Added test cases to verify what used to be failing scenarios.
 - Updated code to fix edge cases.
 - Updated whitespace for consistency.
 - Ported a testcase over from PowerMock to PowerMockito. Some of these fail in the xstream package and since they are existing issues, ignoring those tests in this case.