### PR TITLE
Issue #769: PowerMockMaker with Mockito2.

### DIFF
--- a/powermock-api/powermock-api-mockito2/build.gradle
+++ b/powermock-api/powermock-api-mockito2/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    testCompile(project(":tests:utils"))
+}

--- a/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/internal/pluginswitch/PowerMockPluginSwitch.java
+++ b/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/internal/pluginswitch/PowerMockPluginSwitch.java
@@ -1,0 +1,23 @@
+package org.powermock.api.mockito.internal.pluginswitch;
+
+import org.mockito.Mockito;
+import org.mockito.plugins.PluginSwitch;
+import org.powermock.api.mockito.internal.mockmaker.PowerMockMaker;
+
+public class PowerMockPluginSwitch implements PluginSwitch {
+
+    @Override
+    public boolean isEnabled(String pluginClassName) {
+        return true;
+    }
+
+    public static void disablePowerMockMaker() {
+        PowerMockMaker.disablePowerMockMaker();
+        Mockito.reset();
+    }
+
+    public static void enablePowerMockMaker() {
+        PowerMockMaker.enablePowerMockMaker();
+        Mockito.reset();
+    }
+}

--- a/powermock-api/powermock-api-mockito2/src/test/java/org/powermock/api/mockito/internal/pluginswitch/PowerMockPluginSwitchTest.java
+++ b/powermock-api/powermock-api-mockito2/src/test/java/org/powermock/api/mockito/internal/pluginswitch/PowerMockPluginSwitchTest.java
@@ -1,0 +1,50 @@
+package org.powermock.api.mockito.internal.pluginswitch;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.exceptions.misusing.MissingMethodInvocationException;
+import samples.classwithnonpublicparent.ClassWithNonPublicParent;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PowerMockPluginSwitchTest {
+
+    private String mSomeOtherString = "some other string";
+
+    @After
+    @Before
+    public void setup() {
+        PowerMockPluginSwitch.enablePowerMockMaker();
+    }
+
+    @Test(expected=MissingMethodInvocationException.class)
+    public void test_PowerMockMakerEnabled_Throws() {
+        PowerMockPluginSwitch.enablePowerMockMaker();
+        ClassWithNonPublicParent mockClassWithNonPublicParent = mock(ClassWithNonPublicParent.class);
+        when(mockClassWithNonPublicParent.getSomeStringFromPackageProtectedClass()).thenReturn(mSomeOtherString);
+        PowerMockPluginSwitch.disablePowerMockMaker();
+    }
+
+    @Test
+    public void test_PowerMockMakerDisabled_MocksMethod() {
+        PowerMockPluginSwitch.disablePowerMockMaker();
+        ClassWithNonPublicParent mockClassWithNonPublicParent = mock(ClassWithNonPublicParent.class);
+        when(mockClassWithNonPublicParent.getSomeStringFromPackageProtectedClass()).thenReturn(mSomeOtherString);
+        Assert.assertEquals(mSomeOtherString, mockClassWithNonPublicParent.getSomeStringFromPackageProtectedClass());
+    }
+
+    @Test
+    public void test_PowerMockMaker_SwitchesCorrectly() {
+        test_PowerMockMakerDisabled_MocksMethod();
+        try {
+            test_PowerMockMakerEnabled_Throws();
+        } catch (MissingMethodInvocationException e) {
+            return;
+        }
+        assertTrue("Expected exception not thrown.", false);
+    }
+}

--- a/powermock-api/powermock-api-mockito2/src/test/resources/mockito-extensions/org.mockito.plugins.PluginSwitch
+++ b/powermock-api/powermock-api-mockito2/src/test/resources/mockito-extensions/org.mockito.plugins.PluginSwitch
@@ -1,0 +1,1 @@
+org.powermock.api.mockito.internal.pluginswitch.PowerMockPluginSwitch

--- a/tests/utils/src/main/java/samples/classwithnonpublicparent/ClassWithNonPublicParent.java
+++ b/tests/utils/src/main/java/samples/classwithnonpublicparent/ClassWithNonPublicParent.java
@@ -1,0 +1,9 @@
+package samples.classwithnonpublicparent;
+
+public class ClassWithNonPublicParent extends PackageProtectedClass {}
+
+class PackageProtectedClass {
+    public String getSomeStringFromPackageProtectedClass() {
+        return "some string";
+    }
+}


### PR DESCRIPTION
This is the workaround mentioned in the issue that can be updated once when https://github.com/mockito/mockito/issues/1003 is fixed.

This implements a Mockito PluginSwitch which currently cannot keep state as there is no way to reload plugins. This stores state in PowerMockMaker to allow users to take advantage of Mockito 2 features for some tests in a project that utilizes PowerMock until Byte Buddy is fully integrated.