### PR TITLE
Fixes #772: PowerMockIgnorePackagesExtractorImpl should visit interfaces 

### DIFF
--- a/powermock-core/src/main/java/org/powermock/tests/utils/impl/PowerMockIgnorePackagesExtractorImpl.java
+++ b/powermock-core/src/main/java/org/powermock/tests/utils/impl/PowerMockIgnorePackagesExtractorImpl.java
@@ -20,15 +20,17 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.tests.utils.IgnorePackagesExtractor;
 
 import java.lang.reflect.AnnotatedElement;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 public class PowerMockIgnorePackagesExtractorImpl implements IgnorePackagesExtractor {
 
     @Override
     public String[] getPackagesToIgnore(AnnotatedElement element) {
-        List<String> ignoredPackages = new LinkedList<String>();
+        Set<String> ignoredPackages = new LinkedHashSet<String>();
         PowerMockIgnore annotation = element.getAnnotation(PowerMockIgnore.class);
         if (annotation != null) {
             String[] ignores = annotation.value();
@@ -36,10 +38,14 @@ public class PowerMockIgnorePackagesExtractorImpl implements IgnorePackagesExtra
         }
         if (element instanceof Class<?>) {
             Class<?> klazz = (Class<?>) element;
-            Class<?> superclass = klazz.getSuperclass();
-            if (superclass != null && !superclass.equals(Object.class)) {
-                String[] packagesToIgnore = getPackagesToIgnore(superclass);
-                Collections.addAll(ignoredPackages, packagesToIgnore);
+            Collection<Class<?>> superclasses = new ArrayList<Class<?>>();
+            Collections.addAll(superclasses, klazz.getSuperclass());
+            Collections.addAll(superclasses, klazz.getInterfaces());
+            for(Class<?> superclass : superclasses) {
+                if (superclass != null && !superclass.equals(Object.class)) {
+                    String[] packagesToIgnore = getPackagesToIgnore(superclass);
+                    Collections.addAll(ignoredPackages, packagesToIgnore);
+                }
             }
         }
         return ignoredPackages.toArray(new String[ignoredPackages.size()]);

--- a/powermock-core/src/test/java/org/powermock/tests/utils/impl/PowerMockIgnorePackagesExtractorImplTest.java
+++ b/powermock-core/src/test/java/org/powermock/tests/utils/impl/PowerMockIgnorePackagesExtractorImplTest.java
@@ -31,15 +31,18 @@ public class PowerMockIgnorePackagesExtractorImplTest {
     public void shouldFindIgnorePackagesInTheWholeClassHierarchy() throws Exception {
         final PowerMockIgnorePackagesExtractorImpl tested = new PowerMockIgnorePackagesExtractorImpl();
         final String[] packagesToIgnore = tested.getPackagesToIgnore(IgnoreAnnotatedDemoClass.class);
-        assertEquals(4, packagesToIgnore.length);
+        assertEquals(7, packagesToIgnore.length);
         assertEquals("ignore0", packagesToIgnore[0]);
         assertEquals("ignore1", packagesToIgnore[1]);
         assertEquals("ignore2", packagesToIgnore[2]);
         assertEquals("ignore3", packagesToIgnore[3]);
+        assertEquals("ignore4", packagesToIgnore[4]);
+        assertEquals("ignore5", packagesToIgnore[5]);
+        assertEquals("ignore6", packagesToIgnore[6]);
     }
 
     @PowerMockIgnore( { "ignore0", "ignore1" })
-    private class IgnoreAnnotatedDemoClass extends IgnoreAnnotatedDemoClassParent {
+    private class IgnoreAnnotatedDemoClass extends IgnoreAnnotatedDemoClassParent implements IgnoreAnnotatedDemoInterfaceParent2 {
 
     }
 
@@ -49,7 +52,22 @@ public class PowerMockIgnorePackagesExtractorImplTest {
     }
 
     @PowerMockIgnore("ignore3")
-    private class IgnoreAnnotatedDemoClassGrandParent {
+    private class IgnoreAnnotatedDemoClassGrandParent implements IgnoreAnnotatedDemoInterfaceParent1 {
 
+    }
+
+    @PowerMockIgnore("ignore4")
+    private interface IgnoreAnnotatedDemoInterfaceParent1 extends IgnoreAnnotatedDemoInterfaceGrandParent {
+
+    }
+
+    @PowerMockIgnore("ignore5")
+    private interface IgnoreAnnotatedDemoInterfaceGrandParent {
+
+    }
+
+    @PowerMockIgnore("ignore6")
+    private interface IgnoreAnnotatedDemoInterfaceParent2 extends IgnoreAnnotatedDemoInterfaceGrandParent {
+        // Test diamond interface hierarchies
     }
 }


### PR DESCRIPTION
Fixes #772
Do a DFS on superclass + interfaces hierarchy to find all PowerMockIgnore annotations. Avoid duplication introduced by diamond interface hierarchies by storing packages in a set.