### PR TITLE
Implement #801 PowerMock Configuration: Global Ignore

### DIFF
--- a/powermock-core/src/main/java/org/powermock/configuration/Configuration.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/Configuration.java
@@ -18,5 +18,6 @@
 
 package org.powermock.configuration;
 
-public interface Configuration {
+public interface Configuration <T extends Configuration>{
+     T merge(T configuration);
 }

--- a/powermock-core/src/main/java/org/powermock/configuration/ConfigurationType.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/ConfigurationType.java
@@ -19,12 +19,16 @@
 package org.powermock.configuration;
 
 public enum ConfigurationType {
-    Mockito("mockito");
+    Mockito("mockito", MockitoConfiguration.class),
+    PowerMock("powermock", PowerMockConfiguration.class);
     
     private final String prefix;
+    private final Class<? extends Configuration> configurationClass;
     
-    ConfigurationType(final String prefix) {
+    ConfigurationType(final String prefix,
+                      final Class<? extends Configuration> configurationClass) {
         this.prefix = prefix;
+        this.configurationClass = configurationClass;
     }
     
     public String getPrefix() {
@@ -32,6 +36,11 @@ public enum ConfigurationType {
     }
     
     public static <T extends Configuration> ConfigurationType forClass(final Class<T> configurationClass) {
-        return Mockito;
+        for (ConfigurationType configurationType : ConfigurationType.values()) {
+            if (configurationType.configurationClass.isAssignableFrom(configurationClass)){
+                return configurationType;
+            }
+        }
+        return null;
     }
 }

--- a/powermock-core/src/main/java/org/powermock/configuration/GlobalConfiguration.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/GlobalConfiguration.java
@@ -18,29 +18,51 @@
 
 package org.powermock.configuration;
 
+import org.powermock.configuration.support.ConfigurationFactoryImpl;
+
 public final class GlobalConfiguration {
     
+    private static ConfigurationFactory configurationFactory = new ConfigurationFactoryImpl();
+    
     private static final ThreadLocal<MockitoConfiguration> MOCKITO_CONFIGURATION = new ThreadLocal<MockitoConfiguration>();
+    private static final ThreadLocal<PowerMockConfiguration> POWER_MOCK_CONFIGURATION = new ThreadLocal<PowerMockConfiguration>();
     
     public static MockitoConfiguration mockitoConfiguration() {
         return new GlobalConfiguration().getMockitoConfiguration();
+    }
+    
+    public static PowerMockConfiguration powerMockConfiguration() {
+        return new GlobalConfiguration().getPowerMockConfiguration();
+    }
+    
+    public static void clear() {
+        configurationFactory = new ConfigurationFactoryImpl();
+        MOCKITO_CONFIGURATION.remove();
+        POWER_MOCK_CONFIGURATION.remove();
+    }
+    
+    public static void setConfigurationFactory(final ConfigurationFactory configurationFactory) {
+        GlobalConfiguration.configurationFactory = configurationFactory;
     }
     
     private GlobalConfiguration() {
         if (MOCKITO_CONFIGURATION.get() == null) {
             MOCKITO_CONFIGURATION.set(createConfig(MockitoConfiguration.class));
         }
+        if (POWER_MOCK_CONFIGURATION.get() == null) {
+            POWER_MOCK_CONFIGURATION.set(createConfig(PowerMockConfiguration.class));
+        }
     }
     
-    public static void clear() {
-        MOCKITO_CONFIGURATION.remove();
+    private PowerMockConfiguration getPowerMockConfiguration() {
+        return POWER_MOCK_CONFIGURATION.get();
     }
     
     private MockitoConfiguration getMockitoConfiguration() {
         return MOCKITO_CONFIGURATION.get();
     }
     
-    private <T extends Configuration> T createConfig(Class<T> configurationClass) {
-        return new ConfigurationFactory().create(configurationClass);
+    private <T extends Configuration<T>> T createConfig(Class<T> configurationClass) {
+        return configurationFactory.create(configurationClass);
     }
 }

--- a/powermock-core/src/main/java/org/powermock/configuration/MockitoConfiguration.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/MockitoConfiguration.java
@@ -18,9 +18,17 @@
 
 package org.powermock.configuration;
 
-public class MockitoConfiguration implements Configuration {
+public class MockitoConfiguration implements Configuration<MockitoConfiguration> {
     
     private String mockMakerClass;
+    
+    public MockitoConfiguration() {
+        // Used by configuration reader to create an instance
+    }
+    
+    private MockitoConfiguration(final String mockMakerClass) {
+        this.mockMakerClass = mockMakerClass;
+    }
     
     public String getMockMakerClass() {
         return mockMakerClass;
@@ -28,5 +36,14 @@ public class MockitoConfiguration implements Configuration {
     
     public void setMockMakerClass(final String mockMakerClass) {
         this.mockMakerClass = mockMakerClass;
+    }
+    
+    @Override
+    public MockitoConfiguration merge(final MockitoConfiguration configuration) {
+        if (configuration != null && configuration.getMockMakerClass() != null) {
+            return new MockitoConfiguration(configuration.getMockMakerClass());
+        } else {
+            return this;
+        }
     }
 }

--- a/powermock-core/src/main/java/org/powermock/configuration/PowerMockConfiguration.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/PowerMockConfiguration.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *   Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.configuration;
+
+import org.powermock.utils.ArrayUtil;
+
+public class PowerMockConfiguration implements Configuration<PowerMockConfiguration> {
+    private String[] globalIgnore;
+    
+    public String[] getGlobalIgnore() {
+        return globalIgnore;
+    }
+    
+    public void setGlobalIgnore(final String[] globalIgnore) {
+        this.globalIgnore = globalIgnore;
+    }
+    
+    @Override
+    public PowerMockConfiguration merge(final PowerMockConfiguration configuration) {
+        if (configuration == null) {
+            return this;
+        } else {
+            PowerMockConfiguration powerMockConfiguration = new PowerMockConfiguration();
+    
+            String[] globalIgnore = ArrayUtil.mergeArrays(this.globalIgnore, configuration.globalIgnore);
+            
+            powerMockConfiguration.setGlobalIgnore(globalIgnore);
+            
+            return powerMockConfiguration;
+        }
+    }
+    
+}

--- a/powermock-core/src/main/java/org/powermock/configuration/support/ConfigurationFactoryImpl.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/support/ConfigurationFactoryImpl.java
@@ -1,0 +1,57 @@
+/*
+ *
+ *   Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package org.powermock.configuration.support;
+
+import org.powermock.configuration.Configuration;
+import org.powermock.configuration.ConfigurationFactory;
+
+import static org.powermock.configuration.support.ConfigurationReaderBuilder.newBuilder;
+
+public class ConfigurationFactoryImpl implements ConfigurationFactory {
+    
+    private static final String USER_CONFIGURATION = "org/powermock/configuration.properties";
+    private static final String DEFAULT_CONFIGURATION = "org/powermock/default.properties";
+    
+    @Override public <T extends Configuration<T>> T create(final Class<T> configurationType) {
+        T configuration = readUserConfiguration(configurationType);
+        T defaultConfiguration = readDefault(configurationType);
+        return defaultConfiguration.merge(configuration);
+    }
+    
+    private <T extends Configuration> T  readDefault(final Class<T> configurationType) {
+    
+        final T configuration = newBuilder()
+                                    .forConfigurationFile(DEFAULT_CONFIGURATION)
+                                    .build()
+                                    .read(configurationType);
+        if (configuration == null){
+            throw new RuntimeException("It should never happen. If you see this exception, it means that something wrong with build." +
+                                           " Please report to PowerMock issues tracker.");
+        }
+        return configuration;
+    }
+    
+    private <T extends Configuration> T  readUserConfiguration(final Class<T> configurationType) {
+        return newBuilder()
+                   .forConfigurationFile(USER_CONFIGURATION)
+                   .withValueAlias("mock-maker-inline", "org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker")
+                   .build()
+                   .read(configurationType);
+    }
+}

--- a/powermock-core/src/main/java/org/powermock/core/classloader/DeferSupportingClassLoader.java
+++ b/powermock-core/src/main/java/org/powermock/core/classloader/DeferSupportingClassLoader.java
@@ -83,7 +83,8 @@ public abstract class DeferSupportingClassLoader extends Loader {
         return clazz;
     }
 
-    private Class<?> findLoadedClass1(String name) {SoftReference<Class<?>> reference = classes.get(name);
+    private Class<?> findLoadedClass1(String name) {
+        SoftReference<Class<?>> reference = classes.get(name);
         Class<?> clazz = null;
         if (reference != null) {
            clazz = reference.get();

--- a/powermock-core/src/main/java/org/powermock/tests/utils/impl/MockClassLoaderFactory.java
+++ b/powermock-core/src/main/java/org/powermock/tests/utils/impl/MockClassLoaderFactory.java
@@ -31,9 +31,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- *
- */
 class MockClassLoaderFactory {
     private final String[] packagesToIgnore;
     private final Class<?> testClass;

--- a/powermock-core/src/main/java/org/powermock/utils/ArrayUtil.java
+++ b/powermock-core/src/main/java/org/powermock/utils/ArrayUtil.java
@@ -18,10 +18,11 @@
 package org.powermock.utils;
 
 import java.lang.reflect.Array;
+import java.util.HashSet;
+import java.util.Set;
 
-/**
- *
- */
+import static java.util.Arrays.asList;
+
 public class ArrayUtil {
 
     public static <T> T[] addAll(T[] array1, T[] array2) {
@@ -51,5 +52,27 @@ public class ArrayUtil {
     @SuppressWarnings("unchecked")
     private static <T> T[] createNewArrayWithSameType(T[] arrayPrototype, int newLength) {
         return (T[]) Array.newInstance(arrayPrototype[0].getClass(), newLength);
+    }
+    
+    public static String[] mergeArrays(final String[] firstArray, final String[] secondArray) {
+        
+        if (firstArray == null && secondArray == null){
+            return null;
+        }
+        
+        if (firstArray == null){
+            return secondArray;
+        }
+    
+        if (secondArray == null){
+            return firstArray;
+        }
+        
+        Set<String> globalIgnore = new HashSet<String>();
+        
+        globalIgnore.addAll(asList(firstArray));
+        globalIgnore.addAll(asList(secondArray));
+        
+        return globalIgnore.toArray(new String[globalIgnore.size()]);
     }
 }

--- a/powermock-core/src/main/java/org/powermock/utils/StringJoiner.java
+++ b/powermock-core/src/main/java/org/powermock/utils/StringJoiner.java
@@ -28,14 +28,19 @@ public class StringJoiner {
 
     public static String join(Object... linesToBreak) {
         StringBuilder out = new StringBuilder(LINE_SEPARATOR);
-        return join(out, linesToBreak);
+        return join(out, linesToBreak, LINE_SEPARATOR);
+    }
+    
+    public static String join(String separator, Object... linesToBreak) {
+        StringBuilder out = new StringBuilder();
+        return join(out, linesToBreak, separator);
     }
 
-    private static String join(StringBuilder out, Object[] linesToBreak) {
+    private static String join(StringBuilder out, Object[] linesToBreak, final String separator) {
         for (Object line : linesToBreak) {
-            out.append(line.toString()).append(LINE_SEPARATOR);
+            out.append(line.toString()).append(separator);
         }
-        int lastBreak = out.lastIndexOf(LINE_SEPARATOR);
+        int lastBreak = out.lastIndexOf(separator);
         return out.replace(lastBreak, lastBreak + 1, EMPTY_STRING).toString();
     }
 

--- a/powermock-core/src/test/java/org/powermock/configuration/ConfigurationFactoryImplTest.java
+++ b/powermock-core/src/test/java/org/powermock/configuration/ConfigurationFactoryImplTest.java
@@ -22,17 +22,21 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.powermock.api.mockito.ConfigurationTestUtils;
+import org.powermock.configuration.support.ConfigurationFactoryImpl;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ConfigurationFactoryTest {
+public class ConfigurationFactoryImplTest {
     
     private ConfigurationFactory configurationFactory;
     private ConfigurationTestUtils util;
     
     @Before
     public void setUp() throws Exception {
-        configurationFactory = new ConfigurationFactory();
+        configurationFactory = new ConfigurationFactoryImpl();
         util = new ConfigurationTestUtils();
     }
     
@@ -46,15 +50,15 @@ public class ConfigurationFactoryTest {
     
         util.copyTemplateToPropertiesFile();
     
-        MockitoConfiguration configuration = configurationFactory.create(MockitoConfiguration.class);
+        PowerMockConfiguration configuration = configurationFactory.create(PowerMockConfiguration.class);
         
         assertThat(configuration)
             .as("Configuration is created")
             .isNotNull();
         
-        assertThat(configuration.getMockMakerClass())
+        assertThat(configuration.getGlobalIgnore())
             .as("Configuration is read correctly")
-            .isEqualTo("TestMockMaker");
+            .containsExactly("org.somepackage");
     }
     
     @Test
@@ -68,8 +72,21 @@ public class ConfigurationFactoryTest {
         assertThat(configuration.getMockMakerClass())
             .as("Configuration is read correctly")
             .isEqualTo("org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker");
-        
     }
     
     
+    @Test
+    public void should_return_default_value_for_configuration_if_user_not_defined() throws Exception {
+        util.copyTemplateToPropertiesFile();
+        
+        MockitoConfiguration configuration = configurationFactory.create(MockitoConfiguration.class);
+    
+        assertThat(configuration)
+            .as("Configuration is created")
+            .isNotNull();
+    
+        assertThat(configuration.getMockMakerClass())
+            .as("Configuration is read correctly")
+            .isEqualTo("org.mockito.internal.creation.bytebuddy.SubclassByteBuddyMockMaker");
+    }
 }

--- a/powermock-core/src/test/java/org/powermock/configuration/ConfigurationReaderTest.java
+++ b/powermock-core/src/test/java/org/powermock/configuration/ConfigurationReaderTest.java
@@ -95,4 +95,15 @@ public class ConfigurationReaderTest {
             .as("Configuration is read")
             .isEqualTo(value);
     }
+    
+    @Test
+    public void should_read_powermock_global_ignore_as_array() {
+    
+        PowerMockConfiguration configuration = reader.read(PowerMockConfiguration.class);
+    
+        assertThat(configuration.getGlobalIgnore())
+            .as("Configuration is read")
+            .containsExactly("org.somepacckage.*","org.other.Class");
+    }
+    
 }

--- a/powermock-core/src/test/resources/org/powermock/configuration.template
+++ b/powermock-core/src/test/resources/org/powermock/configuration.template
@@ -1,1 +1,1 @@
-mockito.mock-maker-class=TestMockMaker
+powermock.global-ignore=org.somepackage

--- a/powermock-core/src/test/resources/org/powermock/configuration/test.properties
+++ b/powermock-core/src/test/resources/org/powermock/configuration/test.properties
@@ -1,1 +1,2 @@
 mockito.mock-maker-class=TestMockMaker
+powermock.global-ignore=org.somepacckage.*,org.other.Class

--- a/tests/mockito/junit4/src/main/java/samples/powermockito/junit4/bugs/github801/GlobalPowerMockIgnore.java
+++ b/tests/mockito/junit4/src/main/java/samples/powermockito/junit4/bugs/github801/GlobalPowerMockIgnore.java
@@ -16,8 +16,7 @@
  *
  */
 
-package org.powermock.configuration;
+package samples.powermockito.junit4.bugs.github801;
 
-public interface ConfigurationFactory {
-    <T extends Configuration<T>> T create(Class<T> configurationType);
+public class GlobalPowerMockIgnore {
 }

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github801/GlobalPowerMockIgnoreTest.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github801/GlobalPowerMockIgnoreTest.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *   Copyright 2017 the original author or authors.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package samples.powermockito.junit4.bugs.github801;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(PowerMockRunner.class)
+public class GlobalPowerMockIgnoreTest {
+    
+    @Test
+    public void should_load_class_from_global_ignore_with_system_class_loader() {
+        GlobalPowerMockIgnore globalPowerMockIgnore = new GlobalPowerMockIgnore();
+        
+        assertThat(globalPowerMockIgnore.getClass().getClassLoader())
+            .as("Class is loaded by System Classloader")
+            .isSameAs(ClassLoader.getSystemClassLoader());
+    }
+    
+}

--- a/tests/mockito/junit4/src/test/resources/org/powermock/configuration.properties
+++ b/tests/mockito/junit4/src/test/resources/org/powermock/configuration.properties
@@ -1,0 +1,1 @@
+powermock.global-ignore=samples.powermockito.junit4.bugs.github801.GlobalPowerMockIgnore


### PR DESCRIPTION
Fix #801 Add ability to set global ignore with using `configuration.properties` file.