### PR TITLE
Fixes #826 Initial configuration of Shipkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ jdk:
 script:
   - ./gradlew assemble
   - ./gradlew check
+  - ./gradlew ciPerformRelease
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'net.researchgate:gradle-release:2.4.0'
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+        classpath 'org.shipkit:shipkit:0.9.2'
     }
 }
 
@@ -39,6 +40,7 @@ ext{
     checkstyleVersion= "7.6.1"
 }
 
+apply plugin: 'org.shipkit.java'
 
 description = 'PowerMock allows you to unit test code normally regarded as untestable.\n' +
         '        For instance it is possible to mock static methods, remove static initializers, allow mocking without dependency\n' +

--- a/gradle/modules.gradle
+++ b/gradle/modules.gradle
@@ -4,6 +4,20 @@ configure(publishableModules) { project ->
     apply from: "${gradleScriptDir}/java-module.gradle"
     apply from: "${gradleScriptDir}/publishing/publishable-module.gradle"
 }
+def unpublishableModules = allprojects - publishableModules
+configure(unpublishableModules) { project ->
+    project.tasks.all {
+        if(it.name == 'publishJavaLibraryPublicationToMavenLocal'){
+            it.enabled = false
+        }
+        if(it.name == 'javadoc'){
+            it.enabled = false
+        }
+        if(it.name == 'bintrayUpload'){
+            it.enabled = false
+        }
+    }
+}
 
 def mockitoDependsModules = [
         project(":powermock-core"),

--- a/gradle/publishing/publish-maven.gradle
+++ b/gradle/publishing/publish-maven.gradle
@@ -1,49 +1,49 @@
 apply plugin: 'maven-publish'
 
-publishing {
-    publications {
-        modulesJar(MavenPublication) {
-            from components.java
-            artifactId project.name
-            artifact sourcesJar
-            artifact javadocJar
-        }
-    }
-}
+//publishing {
+//    publications {
+//        modulesJar(MavenPublication) {
+//            from components.java
+//            artifactId project.name
+//            artifact sourcesJar
+//            artifact javadocJar
+//        }
+//    }
+//}
 
 publishing.publications.all {
-    def devs = ['johanhaleby:Johan Haleby:johan.haleby at jayway.com', 'jakr:Jan Kronquist:jan.kronquist at jayway.com', 'thekingnothing:Arthur Zagretdinov:arthur.zagretdinov at outlook.com']
+    //def devs = ['johanhaleby:Johan Haleby:johan.haleby at jayway.com', 'jakr:Jan Kronquist:jan.kronquist at jayway.com', 'thekingnothing:Arthur Zagretdinov:arthur.zagretdinov at outlook.com']
 
     pom.withXml {
         def root = asNode()
-        root.appendNode('name', 'PowerMock')
-        root.appendNode('packaging', 'jar')
-        root.appendNode('description', project.description)
-        root.appendNode('url', 'http://www.powermock.org')
+//        root.appendNode('name', 'PowerMock')
+//        root.appendNode('packaging', 'jar')
+//        root.appendNode('description', project.description)
+//        root.appendNode('url', 'http://www.powermock.org')
 
-        def license = root.appendNode('licenses').appendNode('license')
-        license.appendNode('name', 'The Apache Software License, Version 2.0')
-        license.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
-        license.appendNode('distribution', 'repo')
+//        def license = root.appendNode('licenses').appendNode('license')
+//        license.appendNode('name', 'The Apache Software License, Version 2.0')
+//        license.appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.txt')
+//        license.appendNode('distribution', 'repo')
+//
+//        def scm = root.appendNode('scm')
+//        scm.appendNode('url', 'http://github.com/mockito/mockito')
+//        scm.appendNode('connection', 'scm:git:git://github.com/powermock/powermock')
+//        scm.appendNode('developerConnection', 'scm:git:git://github.com/powermock/powermock')
 
-        def scm = root.appendNode('scm')
-        scm.appendNode('url', 'http://github.com/mockito/mockito')
-        scm.appendNode('connection', 'scm:git:git://github.com/powermock/powermock')
-        scm.appendNode('developerConnection', 'scm:git:git://github.com/powermock/powermock')
+//        def issues = root.appendNode('issueManagement')
+//        issues.appendNode('url', 'https://github.com/powermock/powermock/issues')
+//        issues.appendNode('system', 'GitHub')
 
-        def issues = root.appendNode('issueManagement')
-        issues.appendNode('url', 'https://github.com/powermock/powermock/issues')
-        issues.appendNode('system', 'GitHub')
-
-        def developers = root.appendNode('developers')
-        devs.each {
-            def split = it.split(':')
-            assert split.length == 3
-            def d = developers.appendNode('developer')
-            d.appendNode('id', split[0])
-            d.appendNode('name', split[1])
-            d.appendNode('email', split[2])
-        }
+//        def developers = root.appendNode('developers')
+//        devs.each {
+//            def split = it.split(':')
+//            assert split.length == 3
+//            def d = developers.appendNode('developer')
+//            d.appendNode('id', split[0])
+//            d.appendNode('name', split[1])
+//            d.appendNode('email', split[2])
+//        }
 
         root.dependencies.'*'.findAll() {
             it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->

--- a/gradle/publishing/publish.gradle
+++ b/gradle/publishing/publish.gradle
@@ -6,23 +6,23 @@ if (project.version.toString().contains("beta")){
 }
 
 bintray {
-    user = System.getenv('BINTRAY_USER')
-    key = System.getenv('BINTRAY_API_KEY')
+    //user = System.getenv('BINTRAY_USER')
+    //key = System.getenv('BINTRAY_API_KEY')
 
     publish = project.ext.bintrayAutoPublish
 
     pkg {
-        repo = project.ext.bintrayRepo
+        //repo = project.ext.bintrayRepo
 
-        name = 'powermock'
-        userOrg ='powermock'
+        //name = 'powermock'
+        //userOrg ='powermock'
 
-        desc = project.description
-        websiteUrl = 'http://powermock.org'
-        issueTrackerUrl = 'https://powermock.com/powermock/powermock/issues'
-        vcsUrl = 'https://github.com/powermock/powermock.git'
-        licenses = ['Apache-2.0']
-        labels = ['java', 'mock', 'mocking', 'tests']
+        //desc = project.description
+        //websiteUrl = 'http://powermock.org'
+        //issueTrackerUrl = 'https://powermock.com/powermock/powermock/issues'
+        //vcsUrl = 'https://github.com/powermock/powermock.git'
+        //licenses = ['Apache-2.0']
+        //labels = ['java', 'mock', 'mocking', 'tests']
         publicDownloadNumbers = true
 
         // optional version attributes

--- a/gradle/publishing/publishable-module.gradle
+++ b/gradle/publishing/publishable-module.gradle
@@ -1,8 +1,8 @@
 ext {
-    bintrayRepo = 'maven'
+    //bintrayRepo = 'maven'
     bintrayAutoPublish = true
     mavenCentralSync = true
-    bintrayPublications = ['modulesJar']
+    bintrayPublications = ['javaLibrary']
 }
 
 jar {
@@ -29,15 +29,15 @@ javadoc {
     failOnError = false
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
+//task sourcesJar(type: Jar, dependsOn: classes) {
+//    classifier = 'sources'
+//    from sourceSets.main.allSource
+//}
 
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
+//task javadocJar(type: Jar, dependsOn: javadoc) {
+//    classifier = 'javadoc'
+//    from javadoc.destinationDir
+//}
 
 artifacts {
     archives sourcesJar

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,0 +1,24 @@
+//This file was created automatically and is intended to be checked-in.
+shipkit {
+   gitHub.repository = "wwilk/powermock"
+
+   //TODO when you finish trying out Shipkit, use your own token below (http://link/needed)
+   gitHub.readOnlyAuthToken = "76826c9ec886612f504d12fd4268b16721c4f85d"
+}
+
+allprojects {
+   plugins.withId("org.shipkit.bintray") {
+       //TODO when you finish trying out Shipkit, use your own Bintray repository below (http://link/needed)
+       bintray {
+           key = '7ea297848ca948adb7d3ee92a83292112d7ae989'
+           pkg {
+               repo = 'bootstrap'
+               user = 'shipkit-bootstrap-bot'
+               userOrg = 'shipkit-bootstrap'
+               name = 'maven'
+               licenses = ['MIT']
+               labels = ['continuous delivery', 'release automation', 'shipkit']
+           }
+       }
+   }
+}


### PR DESCRIPTION
It's still a draft, I created a pull request so that @thekingnothing can see it to find potential problems with the changes I made. 

There is still a few things to do:
- customizing pom elements, like developers, license, scm. For the moment I commented them out.
- probably disabling also other tasks in modules.gradle, like jar or sourcesJar.
- changing repo name in shipkit.gradle

I ran ./gradlew performRelease in root dir. You can see uploaded artifacts [here](https://bintray.com/shipkit-bootstrap/bootstrap/maven/powermock-1.7.1). And [here](https://github.com/wwilk/powermock/commit/e1a27954747b460a50bee2404879e532509564a0) is a commit pushed to my fork.