### PR TITLE
Avoid depending on Mockito internals

### DIFF
--- a/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/PowerMockito.java
+++ b/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/PowerMockito.java
@@ -18,6 +18,7 @@ package org.powermock.api.mockito;
 
 import org.mockito.MockSettings;
 import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 import org.mockito.verification.VerificationMode;
@@ -192,8 +193,23 @@ public class PowerMockito extends MemberModifier {
      */
     @SuppressWarnings("unchecked")
     public static synchronized <T> T spy(T object) {
-        MockSettings mockSettings = Mockito.withSettings().defaultAnswer(Mockito.CALLS_REAL_METHODS);
+        MockSettings mockSettings = Mockito.withSettings().defaultAnswer(new PowermockitoCallRealMethod());
         return DefaultMockCreator.mock((Class<T>) Whitebox.getType(object), false, true, object, mockSettings, (Method[]) null);
+    }
+
+    public static class PowermockitoCallRealMethod implements Answer {
+        //FIXME this static state is a hack that only demonstrates how the use case can be solved!!!
+        public static boolean handledByMockito = false;
+
+        @Override
+        public Object answer(InvocationOnMock invocation) throws Throwable {
+            handledByMockito = true;
+            try {
+                return Mockito.CALLS_REAL_METHODS.answer(invocation);
+            } finally {
+                handledByMockito = false;
+            }
+        }
     }
     
     /**

--- a/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/invocation/MockitoMethodInvocationControl.java
+++ b/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/invocation/MockitoMethodInvocationControl.java
@@ -18,7 +18,7 @@ package org.powermock.api.mockito.invocation;
 
 import org.mockito.Mockito;
 import org.mockito.exceptions.base.MockitoAssertionError;
-import org.mockito.internal.exceptions.stacktrace.StackTraceFilter;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.mockito.internal.invocation.InvocationControlAssertionError;
 import org.powermock.core.MockGateway;
 import org.powermock.core.spi.MethodInvocationControl;
@@ -102,17 +102,9 @@ public class MockitoMethodInvocationControl<T> implements MethodInvocationContro
         final int modifiers = method.getModifiers();
         return hasDelegator() && !Modifier.isPrivate(modifiers) && !Modifier.isFinal(modifiers) && !Modifier.isStatic(modifiers);
     }
-    
+
     private boolean hasBeenCaughtByMockitoProxy() {
-        StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
-        StackTraceFilter filter = new StackTraceFilter();
-        /*
-        * We filter the stack-trace to check if "Mockito" exists as a stack trace element. (The filter method
-        * remove all Mockito stack trace elements). If the filtered stack trace length is not equal to the original stack trace length
-        * this means that the call has been caught by Mockito.
-        */
-        final StackTraceElement[] filteredStackTrace = filter.filter(stackTrace, true);
-        return filteredStackTrace.length != stackTrace.length;
+        return PowerMockito.PowermockitoCallRealMethod.handledByMockito;
     }
     
     @Override


### PR DESCRIPTION
This example implementation (hack) shows that it is possible to identify Mockito method call without the need to introspect current stack trace and without the need to depend on Mockito internal implementation.

It's an example implementation, the target solution should not use static state. We should attach the state to some existing object or at least use ThreadLocal. I have ran all the tests from 'tests-mockito-junit4' and the results were good (some tests fail but I saw those failures without my changes, either).

I hope this commit can help developing clean Powermock integration with Mockito.