### PR TITLE
Fixed #755: Inject candidate is searching by field name also

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ repo
 **/build/**
 .gradle
 **/classes/**
+**/out/**

--- a/powermock-api/powermock-api-easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockMetadata.java
+++ b/powermock-api/powermock-api-easymock/src/main/java/org/powermock/api/extension/listener/AnnotationMockMetadata.java
@@ -31,6 +31,7 @@ public class AnnotationMockMetadata implements MockMetadata {
     private final String qualifier;
     private final Class<? extends Annotation> annotation;
     private final Annotation annotationInstance;
+    private final String fieldName;
     private Object mock;
     
     public AnnotationMockMetadata(Class<? extends Annotation> annotation, Field field) throws
@@ -38,6 +39,7 @@ public class AnnotationMockMetadata implements MockMetadata {
         this.annotation = annotation;
         this.annotationInstance = field.getAnnotation(annotation);
         this.type = field.getType();
+        this.fieldName = field.getName();
         this.methods = getMethod();
         this.qualifier = findQualifier();
     }
@@ -57,7 +59,12 @@ public class AnnotationMockMetadata implements MockMetadata {
             return fieldName;
         }
     }
-
+    
+    @Override
+    public String getFieldName() {
+        return fieldName;
+    }
+    
     @Override
     public String getQualifier() {
         return qualifier;

--- a/powermock-api/powermock-api-easymock/src/main/java/org/powermock/api/extension/listener/DefaultInjectFieldSearcher.java
+++ b/powermock-api/powermock-api-easymock/src/main/java/org/powermock/api/extension/listener/DefaultInjectFieldSearcher.java
@@ -44,9 +44,20 @@ class DefaultInjectFieldSearcher implements InjectFieldSearcher {
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
+        candidates = filterByFieldName(candidates, mockMetadata.getFieldName());
+        if (candidates.size() == 1) {
+            return candidates.iterator().next();
+        }
         return null;
     }
-
+    
+    private Set<Field> filterByFieldName(final Set<Field> candidates, final String fieldName) {
+        if (fieldName == null || fieldName.length() == 0) {
+            return candidates;
+        }
+        return doFilterByQualifier(candidates, fieldName);
+    }
+    
     private Set<Field> filterByType(Set<Field> candidates, Class<?> type) {
         if (type == null) {
             return candidates;

--- a/powermock-api/powermock-api-easymock/src/main/java/org/powermock/api/extension/listener/MockMetadata.java
+++ b/powermock-api/powermock-api-easymock/src/main/java/org/powermock/api/extension/listener/MockMetadata.java
@@ -24,6 +24,8 @@ import java.lang.reflect.Method;
  *
  */
 public interface MockMetadata {
+    String getFieldName();
+    
     String getQualifier();
 
     Class<? extends Annotation> getAnnotation();

--- a/tests/easymock/junit4/src/test/java/samples/junit4/annotationbased/TestSubjectPowermockAnnotationTest.java
+++ b/tests/easymock/junit4/src/test/java/samples/junit4/annotationbased/TestSubjectPowermockAnnotationTest.java
@@ -39,14 +39,10 @@ public class TestSubjectPowermockAnnotationTest {
 
 
     @Test
-    public void injectMocksWorksWithPowermockMock() {
-        assertNotNull("dependencyHolder is null", dependencyHolder.getInjectDemo());
-    }
+    public void should_inject_mock_without_quantifier() throws Exception {
 
-    @Test
-    public void testInjectDemoSay() throws Exception {
-
-        InjectDemo tested = dependencyHolder.getInjectDemo();
+        final InjectDemo tested = dependencyHolder.getInjectDemo();
+        assertNotNull("dependencyHolder is null", tested);
 
         String expected = "Hello altered World";
         expectPrivate(tested,"say","hello").andReturn("Hello altered World");
@@ -58,14 +54,10 @@ public class TestSubjectPowermockAnnotationTest {
     }
 
     @Test
-    public void injectMocksWorksWithPowermockMockWithQualifier() {
-        assertNotNull("dependencyHolder is null", dependencyHolderQualifier.getInjectDemoQualifier());
-    }
-
-    @Test
-    public void testInjectDemoQualifier() throws Exception {
+    public void should_inject_mock_with_quantifier() throws Exception {
 
         InjectDemo tested = dependencyHolderQualifier.getInjectDemoQualifier();
+        assertNotNull("dependencyHolderQualifier is null", tested);
 
         String expected = "Hello altered World";
         expectPrivate(tested,"say","hello").andReturn("Hello altered World");

--- a/tests/easymock/junit412/src/test/java/samples/junit412/bug/github755/TwoObjectsAnnotatedTest.java
+++ b/tests/easymock/junit412/src/test/java/samples/junit412/bug/github755/TwoObjectsAnnotatedTest.java
@@ -1,0 +1,40 @@
+package samples.junit412.bug.github755;
+
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.annotation.Mock;
+import org.powermock.api.easymock.annotation.MockNice;
+import org.powermock.modules.junit4.PowerMockRunner;
+import samples.newmocking.SomeDependency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(PowerMockRunner.class)
+public class TwoObjectsAnnotatedTest {
+    
+    @Mock
+    private String obj1;
+    
+    @Mock
+    private String obj2;
+    
+    @MockNice
+    private SomeDependency someClass1;
+    
+    @MockNice
+    private SomeDependency someClass2;
+    
+    @Test
+    public void should_create_mock_for_all_fields_annotated_Mock() {
+        assertThat(obj1).isNotNull();
+        assertThat(obj2).isNotNull();
+    }
+    
+    @Test
+    public void should_create_mock_for_all_fields_annotated_MockNice() {
+        assertThat(someClass1).isNotNull();
+        assertThat(someClass2).isNotNull();
+    }
+    
+}

--- a/tests/easymock/junit412/src/test/java/samples/junit412/bug/github755/package-info.java
+++ b/tests/easymock/junit412/src/test/java/samples/junit412/bug/github755/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * @Mock annotation from easymock api does not work for two fields of the same type.
+ *
+ */
+package samples.junit412.bug.github755;


### PR DESCRIPTION
Fixed #755 @Mock annotation from easymock api does not work for two fields of the same type: Inject candidate is searching by field name also. [ci maven-central-release]