### PR TITLE
Fix for #840, stack overflow when final equals calls another method on the same instance

### DIFF
--- a/powermock-core/src/main/java/org/powermock/core/MockInvocation.java
+++ b/powermock-core/src/main/java/org/powermock/core/MockInvocation.java
@@ -8,20 +8,22 @@ import org.powermock.reflect.internal.proxy.UnproxiedType;
 import java.lang.reflect.Method;
 
 class MockInvocation {
-    private Object object;
-    private String methodName;
-    private Class<?>[] sig;
+    private final Object object;
+    private final String methodName;
+    private final Class<?>[] sig;
+    private final Object[] args;
     private Class<?> objectType;
     private MethodInvocationControl methodInvocationControl;
     private Method method;
-    
-    MockInvocation(Object object, String methodName, Class<?>... sig) {
+
+    MockInvocation(Object object, String methodName, Class<?>[] sig, Object[] args) {
         this.object = object;
         this.methodName = methodName;
         this.sig = sig;
+        this.args = args;
         init();
     }
-    
+
     private void init() {
         if (object instanceof Class<?>) {
             objectType = (Class<?>) object;
@@ -34,19 +36,27 @@ class MockInvocation {
         }
         method = findMethodToInvoke(methodName, sig, objectType);
     }
-    
+
+    Object getMockInstance() {
+        return object;
+    }
+
+    Object[] getArguments() {
+        return args;
+    }
+
     Class<?> getObjectType() {
         return objectType;
     }
-    
+
     MethodInvocationControl getMethodInvocationControl() {
         return methodInvocationControl;
     }
-    
+
     Method getMethod() {
         return method;
     }
-    
+
     private static Method findMethodToInvoke(String methodName, Class<?>[] sig, Class<?> objectType) {
         /*
         * if invocationControl is null or the method is not mocked, invoke

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEquals.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEquals.java
@@ -1,0 +1,24 @@
+package samples.powermockito.junit4.bugs.github840;
+
+class FinalEquals {
+
+    boolean standardEqualsCalled = false;
+    boolean nonstandardEqualsCalled = false;
+
+    public int method0() {
+        return 17;
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        standardEqualsCalled = true;
+        return other instanceof FinalEquals &&
+               other == this;
+    }
+
+    public final boolean equals(FinalEquals other) {
+        nonstandardEqualsCalled = true;
+        return other == this;
+    }
+
+}

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEquals2.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEquals2.java
@@ -1,0 +1,25 @@
+package samples.powermockito.junit4.bugs.github840;
+
+class FinalEquals2 {
+
+    boolean standardEqualsCalled = false;
+    boolean nonstandardEqualsCalled = false;
+    boolean nonstandardEqualsValue = false;
+
+    public String method6() {
+        return "something";
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        standardEqualsCalled = true;
+        return other instanceof FinalEquals2 &&
+               other == this;
+    }
+
+    public boolean equals(FinalEquals2 other) {
+        nonstandardEqualsCalled = true;
+        return nonstandardEqualsValue;
+    }
+
+}

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEqualsWithNoRefCheck.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEqualsWithNoRefCheck.java
@@ -1,0 +1,18 @@
+package samples.powermockito.junit4.bugs.github840;
+
+class FinalEqualsWithNoRefCheck {
+
+    boolean equalsCalled = false;
+    boolean actualDetermination = false;
+
+    public double aMethod() {
+        return 19d;
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        equalsCalled = true;
+        return actualDetermination;
+    }
+
+}

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEqualsWithOtherCall.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEqualsWithOtherCall.java
@@ -1,0 +1,34 @@
+package samples.powermockito.junit4.bugs.github840;
+
+class FinalEqualsWithOtherCall {
+
+    boolean equalsCalled = false;
+    boolean afterInternalCall = false;
+    boolean nonstandardEqualsValue = false;
+
+    public int method1() {
+        return 1;
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (other instanceof FinalEqualsWithOtherCall) {
+            System.out.println("FinalEqualsWithOtherCall compared to FinalEqualsWithNoRefCheck");
+        }
+        equalsCalled = true;
+        otherMethod();
+        afterInternalCall = true;
+        return other instanceof FinalEqualsWithOtherCall &&
+               other == this;
+    }
+
+    public final boolean equals(FinalEqualsWithOtherCall other) {
+        System.out.println("Equals with specialized parameter");
+        return nonstandardEqualsValue;
+    }
+
+    private void otherMethod() {
+        System.out.println("Calling this method from equals shouldn't cause stack overflows");
+    }
+
+}

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEqualsWithOtherCall2.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/FinalEqualsWithOtherCall2.java
@@ -1,0 +1,40 @@
+package samples.powermockito.junit4.bugs.github840;
+
+class FinalEqualsWithOtherCall2 {
+
+    private FinalEqualsWithOtherCall resource;
+    boolean equalsCalled = false;
+    boolean afterInternalCall = false;
+    boolean callOnResourceSucceeded = false;
+    boolean actualDetermination = false;
+
+    public void setResource(FinalEqualsWithOtherCall resource) {
+        this.resource = resource;
+    }
+
+    public float method2() {
+        return 2f;
+    }
+
+    @Override
+    public final boolean equals(Object other) {
+        if (other instanceof FinalEqualsWithOtherCall) {
+            System.out.println("FinalEqualsWithOtherCall2 compared to FinalEqualsWithOtherCall");
+        }
+        equalsCalled = true;
+        if (resource != null) {
+            resource.method1();
+            callOnResourceSucceeded = true;
+        } else {
+            System.out.println("Resource is null, that's already a problem");
+        }
+        someMethod();
+        afterInternalCall = true;
+        return actualDetermination;
+    }
+
+    private void someMethod() {
+        System.out.println("And you may ask yourself, \"How did I get here?\"");
+    }
+
+}

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/GitHub840Test.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/GitHub840Test.java
@@ -1,0 +1,202 @@
+package samples.powermockito.junit4.bugs.github840;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.exceptions.misusing.InvalidUseOfMatchersException;
+import org.powermock.core.MockGateway;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.never;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({
+    RegularTestClass.class,
+    FinalEquals.class,
+    FinalEqualsWithNoRefCheck.class,
+    FinalEqualsWithOtherCall.class,
+    FinalEqualsWithOtherCall2.class
+})
+public class GitHub840Test {
+
+    @Test
+    public void test_mock_with_final_equals_that_calls_other_methods_does_not_cause_stack_overflow() {
+        FinalEqualsWithOtherCall instance = mock(FinalEqualsWithOtherCall.class);
+        try {
+            when(instance.method1()).thenReturn(2);
+            assertThat(instance.method1()).isEqualTo(2);
+        } catch (StackOverflowError soe) {
+            failTest("Mock threw a stack overflow error", soe);
+        } catch (Throwable t) {
+            failTest("Mock threw a totally unexpected exception", t);
+        }
+    }
+
+    @Test
+    public void test_mocking_final_equals_does_not_cause_invalid_use_of_matchers() {
+        FinalEqualsWithOtherCall instance = mock(FinalEqualsWithOtherCall.class);
+        try {
+            when(instance.equals(any())).thenReturn(true);
+            Object other = new Object();
+            try {
+                assertThat(instance.equals(other)).isTrue();
+            } catch (Throwable ignored) { }
+        } catch (InvalidUseOfMatchersException ex) {
+            failTest("Mocking final equals threw exception", ex);
+        }
+    }
+
+    @Test
+    public void test_mocking_final_equals_does_not_call_actual_method() {
+        FinalEquals instance = mock(FinalEquals.class);
+        when(instance.equals(any())).thenReturn(true);
+        Object other = new Object();
+        try {
+            assertThat(instance.equals(other)).isTrue();
+            assertThat(instance.standardEqualsCalled).isFalse();
+        } catch (Throwable ignored) { }
+    }
+
+    @Test
+    public void test_standard_equals_not_mocked_when_gateway_instructed_to_ignore() {
+        MockGateway.MOCK_STANDARD_METHODS = false;
+        FinalEqualsWithOtherCall instance = mock(FinalEqualsWithOtherCall.class);
+        try {
+            when(instance.equals(any())).thenReturn(true);
+            failTest("Mocking should not work here");
+        } catch (InvalidUseOfMatchersException ignored) { }
+        Object other = new Object();
+        try {
+            assertThat(instance.equals(other)).isTrue();
+            assertThat(instance.equalsCalled).isTrue();
+            verifyPrivate(instance).invoke("otherMethod");
+        } catch (Throwable ignored) { }
+        MockGateway.MOCK_STANDARD_METHODS = true;
+    }
+
+    @Test
+    public void test_mocking_not_confused_by_multiple_classes_with_final_equals() {
+        FinalEqualsWithOtherCall resource = mock(FinalEqualsWithOtherCall.class);
+        FinalEqualsWithOtherCall2 instance = mock(FinalEqualsWithOtherCall2.class);
+        try {
+            doCallRealMethod().when(instance).setResource(any(FinalEqualsWithOtherCall.class));
+            instance.setResource(resource);
+            when(instance.method2()).thenReturn(5f);
+            assertThat(instance.method2()).isEqualTo(5f);
+            verifyPrivate(instance, never()).invoke("someMethod");
+        } catch (StackOverflowError soe) {
+            failTest("Mock threw a stack overflow error", soe);
+        } catch (Throwable ex) {
+            failTest("Mock threw a totally unexpected exception", ex);
+        }
+    }
+
+    @Test
+    public void test_mocking_with_call_to_real_equals_method_works() {
+        FinalEqualsWithOtherCall instance = mock(FinalEqualsWithOtherCall.class);
+        when(instance.equals(any())).thenCallRealMethod();
+        Object other = new Object();
+        try {
+            assertThat(instance.equals(other)).isFalse();
+            assertThat(instance.equalsCalled).isTrue();
+            verifyPrivate(instance).invoke("otherMethod");
+        } catch (Throwable ignored) { }
+    }
+
+    @Test
+    public void test_nonstandard_final_equals_method_is_not_treated_like_standard_equals() {
+        MockGateway.MOCK_STANDARD_METHODS = false;
+        FinalEquals instance = mock(FinalEquals.class);
+        try {
+            when(instance.equals(any())).thenReturn(true);
+            failTest("Mocking should not work here, MOCK_STANDARD_METHODS = false");
+        } catch (InvalidUseOfMatchersException ignored) { }
+        try {
+            when(instance.equals(any(FinalEquals.class))).thenReturn(true);
+            Object other1 = new Object();
+            // Regular equals method should make a normal comparison
+            assertThat(instance.equals(other1)).isFalse();
+            FinalEquals other2 = new FinalEquals();
+            // Non-standard equals method should be mocked
+            assertThat(instance.equals(other2)).isTrue();
+        } catch (InvalidUseOfMatchersException ex) {
+            ex.printStackTrace();
+            failTest("Specialized equals method treated the same as standard equals", ex);
+        }
+        MockGateway.MOCK_STANDARD_METHODS = true;
+    }
+
+    @Test
+    public void test_nonstandard_equals_method_is_not_treated_like_standard_equals() {
+        MockGateway.MOCK_STANDARD_METHODS = false;
+        FinalEquals2 instance = mock(FinalEquals2.class);
+        try {
+            when(instance.equals(any(Object.class))).thenReturn(true);
+            // It is expected that mocking fails for the standard equals method
+            failTest("Mocking should not work here, MOCK_STANDARD_METHODS = false");
+        } catch (InvalidUseOfMatchersException ignored) {
+        } finally {
+            // Reset the flag since the method is actually called during the
+            // attempt to mock it
+            instance.standardEqualsCalled = false;
+        }
+        when(instance.equals(any(FinalEquals2.class))).thenReturn(true);
+        Object other1 = new Object();
+        // Regular equals method should make a normal comparison
+        assertThat(instance.equals(other1)).isFalse();
+        assertThat(instance.standardEqualsCalled).isTrue();
+        FinalEquals2 other2 = new FinalEquals2();
+        instance.nonstandardEqualsValue = false;
+        // Non-standard equals method should be mocked
+        assertThat(instance.equals(other2)).isTrue();
+        assertThat(instance.nonstandardEqualsCalled).isFalse();
+        MockGateway.MOCK_STANDARD_METHODS = true;
+    }
+
+    @Test
+    public void test_absence_of_reference_check_in_final_equals_still_works() {
+        // This test is to prove that if, for whatever reason, the
+        // implementation of a final equals method returns false when
+        // comparing to itself, then allowing the method to PROCEED is
+        // a suboptimal decision. Such an implementation is arguably
+        // deficient, but not unimaginable.
+        FinalEqualsWithNoRefCheck instance = mock(FinalEqualsWithNoRefCheck.class);
+        when(instance.aMethod()).thenReturn(23d);
+        assertThat(instance.aMethod()).isEqualTo(23d);
+    }
+
+    @Test
+    public void test_mocking_nonfinal_nonstandard_equals_works_as_expected() {
+        RegularTestClass instance = mock(RegularTestClass.class);
+        try {
+            when(instance.equals(any(RegularTestClass.class))).thenCallRealMethod();
+            RegularTestClass other = new RegularTestClass();
+            assertThat(instance.equals(other)).isFalse();
+            assertThat(instance.nonstandardEqualsCalled).isTrue();
+        } catch (Throwable ex) {
+            failTest("Unexpected exception", ex);
+        }
+    }
+
+    private void failTest(String msg) {
+        failTest(msg, null);
+    }
+
+    private void failTest(String msg, Throwable t) {
+        System.out.println("\n**************************************************************");
+        System.out.println(msg);
+        System.out.println("**************************************************************\n");
+        if (t != null) {
+            t.printStackTrace();
+        }
+        fail(msg);
+    }
+
+}

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/RegularTestClass.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/bugs/github840/RegularTestClass.java
@@ -1,0 +1,20 @@
+package samples.powermockito.junit4.bugs.github840;
+
+class RegularTestClass {
+
+    boolean standardEqualsCalled = false;
+    boolean nonstandardEqualsCalled = false;
+
+    @Override
+    public boolean equals(Object other) {
+        standardEqualsCalled = true;
+        return other instanceof RegularTestClass &&
+               equals((RegularTestClass)other);
+    }
+
+    public boolean equals(RegularTestClass other) {
+        nonstandardEqualsCalled = true;
+        return other == this;
+    }
+
+}


### PR DESCRIPTION
This is a fix for #840 and some general cleanup of the treatment of equals method in MockGateway. Please let me know if you have questions or suggestions.

I have made this against 1.x because I was unable to get 2.x to build. Also, not all of the unit tests would pass when I cloned the repo. With my change, the best I can say is that no tests fail that passed before (EDIT: clearly I missed something... I will take a look at the failure), and I have tried to include enough tests to cover obvious regressions and to test these changes. I am willing to work with you on getting the change to the right place if needed, but I may need some pointers on how to properly set up the dev environment.

Also, if you are interested, I can offer suggestions for a sort of new feature related to this, which is the ability to mock the standard equals and hashCode methods when using Mockito. I doubt that's a much needed feature, so I am not planning to put up a pull request unless you think it worthwhile.

Thanks.