### PR TITLE
Fixes #891 allows whenNew.withAnyArguments to match null arguments

### DIFF
--- a/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/internal/expectation/DelegatingToConstructorsOngoingStubbing.java
+++ b/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/mockito/internal/expectation/DelegatingToConstructorsOngoingStubbing.java
@@ -143,7 +143,7 @@ public class DelegatingToConstructorsOngoingStubbing<T> implements OngoingStubbi
                 Object[] paramArgs = new Object[parameterTypesForCtor.length];
                 for (int i = 0; i < parameterTypesForCtor.length; i++) {
                     Class<?> paramType = parameterTypesForCtor[i];
-                    paramArgs[i] = ArgumentMatchers.any(paramType);
+                    paramArgs[i] = ArgumentMatchers.nullable(paramType);
                 }
                 try {
                     final OngoingStubbing<T> when = when(mock.performSubstitutionLogic(paramArgs));

--- a/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/whennew/WhenNewCases.java
+++ b/tests/mockito/junit4/src/test/java/samples/powermockito/junit4/whennew/WhenNewCases.java
@@ -29,6 +29,7 @@ import samples.expectnew.ExpectNewDemo;
 import samples.expectnew.ExpectNewServiceUser;
 import samples.expectnew.ExpectNewWithMultipleCtorDemo;
 import samples.expectnew.ITarget;
+import samples.expectnew.MultiConstructor;
 import samples.expectnew.SimpleVarArgsConstructorDemo;
 import samples.expectnew.Target;
 import samples.expectnew.VarArgsConstructorDemo;
@@ -57,7 +58,7 @@ import static org.powermock.api.support.membermodification.MemberMatcher.constru
  * Test class to demonstrate new instance mocking using whenConstructionOf(..).
  */
 @PrepareForTest({MyClass.class, ExpectNewDemo.class, ClassWithInnerMembers.class, DataInputStream.class,
-        WhenNewCases.class, Target.class})
+        WhenNewCases.class, Target.class, MultiConstructor.class})
 public class WhenNewCases {
 
     public static final String TARGET_NAME = "MyTarget";
@@ -899,5 +900,25 @@ public class WhenNewCases {
             }
         });
         assertThat(actualTarget).isEqualToComparingFieldByField(expectedTarget);
+    }
+
+    @Test
+    public void multiConstructorMatching() throws Exception {
+
+        MultiConstructor expectedObject = new MultiConstructor("only");
+
+        whenNew(MultiConstructor.class).withAnyArguments().thenReturn(expectedObject);
+
+        MultiConstructor actualObject = new MultiConstructor(null);
+        assertNotNull("withAnyArguments did not match constructor(String=null)", actualObject);
+        assertEquals("only", actualObject.getFirst());
+
+        actualObject = new MultiConstructor("first", null);
+        assertNotNull("withAnyArguments did not match constructor(String, String=null)", actualObject);
+        assertEquals("only", actualObject.getFirst());
+
+        actualObject = new MultiConstructor("first", null, true);
+        assertNotNull("withAnyArguments did not match constructor(Runnable=null, boolean, Object)", actualObject);
+        assertEquals("only", actualObject.getFirst());
     }
 }

--- a/tests/utils/src/main/java/samples/expectnew/MultiConstructor.java
+++ b/tests/utils/src/main/java/samples/expectnew/MultiConstructor.java
@@ -1,0 +1,29 @@
+package samples.expectnew;
+
+/**
+ * Mocking object construction with {@code withAnyArguments()} does not treat all
+ * the object's constructors equally. This test fixture provides an object which
+ * has multiple constructors so that tests can cover both code-paths of constructor
+ * matching.
+ */
+public class MultiConstructor {
+
+    private final String first;
+
+    public MultiConstructor(String first, String second) {
+        this.first = first;
+    }
+
+    public MultiConstructor(String first) {
+        this.first = first;
+
+    }
+
+    public MultiConstructor(String first, Runnable something, boolean b) {
+        this.first = first;
+    }
+
+    public String getFirst() {
+        return this.first;
+    }
+}


### PR DESCRIPTION
Fixes constructor generated matchers to include allowance for `null` arguments.