### PR TITLE
Upgrade byte-buddy and EasyMock

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,8 @@ buildscript {
 ext{
     gradleScriptDir = "${rootProject.projectDir}/gradle"
 
-    byteBuddy = "1.7.5"
-    easymockVersion = "3.5"
+    byteBuddy = "1.8.3"
+    easymockVersion = "3.5.1"
     hamcrestVersion = "1.3"
     assertjVersion = "2.6.0"
     cglibVersion = "3.2.5"


### PR DESCRIPTION
byte-buddy 1.8.x adds support for Java 10:

https://github.com/raphw/byte-buddy/blob/master/release-notes.md

EasyMock 3.5.1 includes minor fixes.