### PR TITLE
Fixes #727 Use ByteBuddy to instrument classes instead Javassist:

### DIFF
--- a/powermock-core/src/main/java/org/powermock/core/classloader/ByteCodeFramework.java
+++ b/powermock-core/src/main/java/org/powermock/core/classloader/ByteCodeFramework.java
@@ -3,6 +3,7 @@ package org.powermock.core.classloader;
 import org.powermock.configuration.GlobalConfiguration;
 import org.powermock.core.classloader.annotations.PrepareEverythingForTest;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.core.classloader.annotations.UseClassPathAdjuster;
 import org.powermock.core.classloader.bytebuddy.ByteBuddyMockClassLoader;
@@ -68,6 +69,8 @@ public enum ByteCodeFramework {
     private static ByteCodeFramework getByteCodeFramework(final AnnotatedElement element) {
         if (element.isAnnotationPresent(PrepareForTest.class)) {
             return element.getAnnotation(PrepareForTest.class).byteCodeFramework();
+        } else if (element.isAnnotationPresent(PrepareOnlyThisForTest.class)) {
+            return element.getAnnotation(PrepareOnlyThisForTest.class).byteCodeFramework();
         } else if (element.isAnnotationPresent(PrepareEverythingForTest.class)) {
             return element.getAnnotation(PrepareEverythingForTest.class).byteCodeFramework();
         } else if (element.isAnnotationPresent(SuppressStaticInitializationFor.class)){

--- a/powermock-core/src/main/java/org/powermock/core/classloader/annotations/PrepareOnlyThisForTest.java
+++ b/powermock-core/src/main/java/org/powermock/core/classloader/annotations/PrepareOnlyThisForTest.java
@@ -16,6 +16,7 @@
 package org.powermock.core.classloader.annotations;
 
 import org.powermock.core.IndicateReloadClass;
+import org.powermock.core.classloader.ByteCodeFramework;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -71,4 +72,6 @@ public @interface PrepareOnlyThisForTest {
 	Class<?>[] value() default IndicateReloadClass.class;
 
 	String[] fullyQualifiedNames() default "";
+    
+    ByteCodeFramework byteCodeFramework() default ByteCodeFramework.Javassist;
 }

--- a/powermock-core/src/test/java/org/powermock/core/classloader/MockClassLoaderFactoryTest.java
+++ b/powermock-core/src/test/java/org/powermock/core/classloader/MockClassLoaderFactoryTest.java
@@ -12,9 +12,11 @@ import org.powermock.core.classloader.MockClassLoaderFactoryTest.TestContainer.B
 import org.powermock.core.classloader.MockClassLoaderFactoryTest.TestContainer.ExceptionTestClass;
 import org.powermock.core.classloader.MockClassLoaderFactoryTest.TestContainer.JavassistTestClass;
 import org.powermock.core.classloader.MockClassLoaderFactoryTest.TestContainer.PrepareEverythingForTestTestClass;
+import org.powermock.core.classloader.MockClassLoaderFactoryTest.TestContainer.PrepareOnlyThisForTestTestClass;
 import org.powermock.core.classloader.MockClassLoaderFactoryTest.TestContainer.SuppressStaticInitializationForTestClass;
 import org.powermock.core.classloader.annotations.PrepareEverythingForTest;
 import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.core.classloader.bytebuddy.ByteBuddyMockClassLoader;
 import org.powermock.core.classloader.javassist.JavassistMockClassLoader;
@@ -100,6 +102,7 @@ public class MockClassLoaderFactoryTest {
             
             parameters.add(new Object[]{JavassistTestClass.class, JavassistMockClassLoader.class});
             parameters.add(new Object[]{ByteBuddyTestClass.class, ByteBuddyMockClassLoader.class});
+            parameters.add(new Object[]{PrepareOnlyThisForTestTestClass.class, ByteBuddyMockClassLoader.class});
             
             return parameters;
         }
@@ -190,6 +193,7 @@ public class MockClassLoaderFactoryTest {
             final ArrayList<Object[]> parameters = new ArrayList<Object[]>();
             
             parameters.add(new Object[]{JavassistTestClass.class, "powermock.test.support.MainMockTransformerTestSupport$SupportClasses"});
+            parameters.add(new Object[]{PrepareOnlyThisForTestTestClass.class, "powermock.test.support.MainMockTransformerTestSupport$SupportClasses"});
             parameters.add(new Object[]{ByteBuddyTestClass.class, "powermock.test.support.MainMockTransformerTestSupport$SupportClasses"});
             parameters.add(new Object[]{SuppressStaticInitializationForTestClass.class, "SupportClasses.FinalInnerClass"});
             parameters.add(new Object[]{PrepareEverythingForTestTestClass.class, "*"});
@@ -242,6 +246,20 @@ public class MockClassLoaderFactoryTest {
             public void someTestWithoutPrepareForTest() {
             }
             
+        }
+    
+        @PrepareOnlyThisForTest(value = SupportClasses.class, byteCodeFramework = ByteCodeFramework.ByteBuddy)
+        public static class PrepareOnlyThisForTestTestClass {
+        
+            @Test
+            @PrepareOnlyThisForTest(value = SupportClasses.class, byteCodeFramework = ByteCodeFramework.ByteBuddy)
+            public void someTestWithPrepareForTest() {
+            }
+        
+            @Test
+            public void someTestWithoutPrepareForTest() {
+            }
+        
         }
         
         @SuppressStaticInitializationFor("SupportClasses.FinalInnerClass")


### PR DESCRIPTION
Fixes #727: fix issue with @PrepareOnlyThisForTest. Provide ability specify ByteCodeFramework