### PR TITLE
Issue 939: Error with setInternalState and JDK12 "java.lang.NoSuchFieldException: modifiers

### DIFF
--- a/powermock-modules/powermock-module-junit4/src/main/java/org/powermock/modules/junit4/PowerMockRunner.java
+++ b/powermock-modules/powermock-module-junit4/src/main/java/org/powermock/modules/junit4/PowerMockRunner.java
@@ -58,7 +58,16 @@ public class PowerMockRunner extends AbstractCommonPowerMockRunner {
         try {
             super.run(notifier);
         } finally {
-            Whitebox.setInternalState(description, "fAnnotations", new Annotation[]{});
+            try {
+               Whitebox.setInternalState(description, "fAnnotations", new Annotation[]{});
+            } catch (RuntimeException err) {
+               if (err.getCause() instanceof java.lang.NoSuchFieldException
+                    && err.getCause().getMessage().equals("modifiers")) {
+                // on JDK12 you cannot change 'modifiers'
+               } else {
+                  throw err;
+               }
+            }
         }
     }
 }


### PR DESCRIPTION
Add a catch clause in order to workaround a problem with PowerMockRunner and JDK12

Signed-off-by: Enrico Olivelli - Diennea <enrico.olivelli@diennea.com>

Fixes #939 