### PR TITLE
Fixes #888: Disable Security of X-Stream

### DIFF
--- a/powermock-classloading/powermock-classloading-xstream/src/main/java/org/powermock/classloading/DeepCloner.java
+++ b/powermock-classloading/powermock-classloading-xstream/src/main/java/org/powermock/classloading/DeepCloner.java
@@ -33,8 +33,14 @@ public class DeepCloner implements DeepClonerSPI {
 	 */
 	public DeepCloner(ClassLoader classLoader) {
         xStream = new XStream();
-        xStream.omitField(SingleClassloaderExecutor.class, "classloader");
+		disableSecurity();
+		xStream.omitField(SingleClassloaderExecutor.class, "classloader");
         xStream.setClassLoader(classLoader);
+	}
+
+	private void disableSecurity() {
+		XStream.setupDefaultSecurity(xStream);
+		xStream.allowTypesByRegExp(new String[]{".*"});
 	}
 
 	/**


### PR DESCRIPTION
JDK9, power mockito 2.0.0-beta.5 -
final class issue when mocking static method #888

Unconfigured security in X-Stream leads to error message during build:
"Security framework of XStream not initialized,
XStream is probably vulnerable."

This commit will configure XStream security by allowing all types.