### PR TITLE
Fix changing final fields on Java 12

### DIFF
--- a/powermock-modules/powermock-module-junit4/src/main/java/org/powermock/modules/junit4/PowerMockRunner.java
+++ b/powermock-modules/powermock-module-junit4/src/main/java/org/powermock/modules/junit4/PowerMockRunner.java
@@ -58,16 +58,7 @@ public class PowerMockRunner extends AbstractCommonPowerMockRunner {
         try {
             super.run(notifier);
         } finally {
-            try {
-               Whitebox.setInternalState(description, "fAnnotations", new Annotation[]{});
-            } catch (RuntimeException err) {
-               if (err.getCause() instanceof java.lang.NoSuchFieldException
-                    && err.getCause().getMessage().equals("modifiers")) {
-                // on JDK12 you cannot change 'modifiers'
-               } else {
-                  throw err;
-               }
-            }
+            Whitebox.setInternalState(description, "fAnnotations", new Annotation[]{});
         }
     }
 }

--- a/powermock-reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/powermock-reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -2347,7 +2347,33 @@ public class WhiteboxImpl {
 
     private static void sedModifiersToField(Field fieldToRemoveFinalFrom, int fieldModifiersMaskWithoutFinal) throws IllegalAccessException {
         try {
-            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            Field modifiersField = null;
+            try {
+                modifiersField = Field.class.getDeclaredField("modifiers");
+            } catch (NoSuchFieldException e) {
+                try {
+                    Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+                    boolean accessibleBeforeSet = getDeclaredFields0.isAccessible();
+                    getDeclaredFields0.setAccessible(true);
+                    Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
+                    getDeclaredFields0.setAccessible(accessibleBeforeSet);
+                    for (Field field : fields) {
+                        if ("modifiers".equals(field.getName())) {
+                            modifiersField = field;
+                            break;
+                        }
+                    }
+                    if (modifiersField == null) {
+                        throw e;
+                    }
+                } catch (NoSuchMethodException ex) {
+                    e.addSuppressed(ex);
+                    throw e;
+                } catch (InvocationTargetException ex) {
+                    e.addSuppressed(ex);
+                    throw e;
+                }
+            }
             boolean accessibleBeforeSet = modifiersField.isAccessible();
             modifiersField.setAccessible(true);
             modifiersField.setInt(fieldToRemoveFinalFrom, fieldModifiersMaskWithoutFinal);


### PR DESCRIPTION
This also properly fixes #939 and removes the work-around that was put in place with #955.
If Java compatibility gets increased to Java 9 or newer, MethodHandle and VarHandle could be used afair.
But as Java compatibility is 7 currently, I solved it by using yet another private detail,
the method that delivers the declared fields unfiltered where the modifiers field is still included.