### PR TITLE
Fix Whitebox.getAllInstanceFields returning static fields for classes

### DIFF
--- a/powermock-reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
+++ b/powermock-reflect/src/test/java/org/powermock/reflect/WhiteBoxTest.java
@@ -535,6 +535,12 @@ public class WhiteBoxTest {
     }
 
     @Test
+    public void testGetAllInstanceFieldsOnClass() {
+        Set<Field> allFields = Whitebox.getAllInstanceFields(ClassWithChildThatHasInternalState.class);
+        assertEquals(8, allFields.size());
+    }
+
+    @Test
     public void testGetAllStaticFields_assertNoFieldsFromParent() throws Exception {
         Set<Field> allFields = Whitebox.getAllStaticFields(ClassWithChildThatHasInternalState.class);
         assertEquals(0, allFields.size());


### PR DESCRIPTION
Previously if you gave some class object, you got the static fields from the method getAllInstanceFields.
Now you properly get the instance fields of instances of the given class.