### PR TITLE
Fix missing stackmap frames

### DIFF
--- a/powermock-modules/powermock-module-javaagent/src/main/java/org/powermock/modules/agent/DefinalizingClassTransformer.java
+++ b/powermock-modules/powermock-module-javaagent/src/main/java/org/powermock/modules/agent/DefinalizingClassTransformer.java
@@ -20,22 +20,18 @@ import net.bytebuddy.jar.asm.ClassReader;
 import net.bytebuddy.jar.asm.ClassWriter;
 
 import java.lang.instrument.ClassFileTransformer;
-import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
 
 public class DefinalizingClassTransformer extends AbstractClassTransformer implements ClassFileTransformer {
+    private static final int NO_FLAGS_OR_OPTIONS = 0;
 
-     
-    
-    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+    public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
         if (loader == null || shouldIgnore(className)) {
             return null;
         }
         final ClassReader reader = new ClassReader(classfileBuffer);
-        final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
-        reader.accept(new PowerMockClassVisitor(writer),
-                ClassReader.SKIP_FRAMES);
+        final ClassWriter writer = new ClassWriter(NO_FLAGS_OR_OPTIONS);
+        reader.accept(new DefinalizingClassVisitor(writer), NO_FLAGS_OR_OPTIONS);
         return writer.toByteArray();
     }
-
 }

--- a/powermock-modules/powermock-module-javaagent/src/main/java/org/powermock/modules/agent/DefinalizingClassVisitor.java
+++ b/powermock-modules/powermock-module-javaagent/src/main/java/org/powermock/modules/agent/DefinalizingClassVisitor.java
@@ -4,9 +4,9 @@ import net.bytebuddy.jar.asm.ClassVisitor;
 import net.bytebuddy.jar.asm.MethodVisitor;
 import net.bytebuddy.jar.asm.Opcodes;
 
-class PowerMockClassVisitor extends ClassVisitor {
+class DefinalizingClassVisitor extends ClassVisitor {
 
-    public PowerMockClassVisitor(ClassVisitor classVisitor) {
+    public DefinalizingClassVisitor(ClassVisitor classVisitor) {
         super(Opcodes.ASM5, classVisitor);
     }
 

--- a/tests/easymock/junit4-agent/src/test/java/samples/powermockito/junit4/agent/AnnotationUsageTest.java
+++ b/tests/easymock/junit4-agent/src/test/java/samples/powermockito/junit4/agent/AnnotationUsageTest.java
@@ -19,7 +19,6 @@ package samples.powermockito.junit4.agent;
 import org.easymock.Mock;
 import org.easymock.TestSubject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,8 +71,6 @@ public class AnnotationUsageTest {
         replay(server);
     }
 
-
-    @Ignore
     @Test
     public void annotationsAreEnabledWhenUsingTheJUnitRule() {
         String serviceMessage = tested.getServiceMessage();

--- a/tests/easymock/junit4-agent/src/test/java/samples/powermockito/junit4/agent/LargeMethodTest.java
+++ b/tests/easymock/junit4-agent/src/test/java/samples/powermockito/junit4/agent/LargeMethodTest.java
@@ -1,6 +1,5 @@
 package samples.powermockito.junit4.agent;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -24,7 +23,6 @@ public class LargeMethodTest {
     @Rule
     public PowerMockRule powerMockRule = new PowerMockRule();
 
-    @Ignore
     @Test
     public void largeMethodShouldBeOverridden() {
         try {
@@ -36,14 +34,12 @@ public class LargeMethodTest {
         }
     }
 
-    @Ignore
     @Test
     public void largeMethodShouldBeAbleToBeSuppressed() {
         suppress(method(MethodExceedingJvmLimit.class, "init"));
         assertNull("Suppressed method should return: null", MethodExceedingJvmLimit.init());
     }
 
-    @Ignore
     @Test
     public void largeMethodShouldBeAbleToBeMocked() {
         mockStatic(MethodExceedingJvmLimit.class);
@@ -52,7 +48,6 @@ public class LargeMethodTest {
         assertEquals("Mocked method should return: ok", "ok", MethodExceedingJvmLimit.init());
     }
 
-    @Ignore
     @Test(expected = IllegalStateException.class)
     public void largeMethodShouldBeAbleToBeMockedAndThrowException() {
         mockStatic(MethodExceedingJvmLimit.class);

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/AnnotationDemoTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/AnnotationDemoTest.java
@@ -21,7 +21,7 @@ public class AnnotationDemoTest extends PowerMockTestCase {
     @Mock
     private Service serviceMock;
 
-    @Test(enabled = false)
+    @Test
     public void assertInjectionWorked() throws Exception {
         AnnotationDemo tested = new AnnotationDemo(serviceMock);
         final String expected = "mock";

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/AnnotationDemoWithBeforeMethodTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/AnnotationDemoWithBeforeMethodTest.java
@@ -29,7 +29,7 @@ public class AnnotationDemoWithBeforeMethodTest extends PowerMockTestCase {
 		tested = new AnnotationDemo(serviceMock);
 	}
 
-	@Test(enabled = false)
+	@Test
     @PrepareForTest
 	public void assertInjectionWorked() throws Exception {
 		final String expected = "mock";

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/FinalDemoTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/FinalDemoTest.java
@@ -28,12 +28,12 @@ import static org.testng.AssertJUnit.assertEquals;
 
 /**
  * Test class to demonstrate non-static final mocking.
- * 
+ *
  */
 @PrepareForTest(FinalDemo.class)
 public class FinalDemoTest extends PowerMockTestCase {
 
-	@Test(enabled = false)
+	@Test
 	public void testSay() throws Exception {
 		FinalDemo tested = createMock(FinalDemo.class);
 		String expected = "Hello altered World";
@@ -55,7 +55,7 @@ public class FinalDemoTest extends PowerMockTestCase {
 
 	}
 
-	@Test(enabled = false)
+	@Test
 	public void testSayFinalNative() throws Exception {
 		FinalDemo tested = createMock(FinalDemo.class);
 		String expected = "Hello altered World";

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/MockStaticExtendsPowerMockTestCaseTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/MockStaticExtendsPowerMockTestCaseTest.java
@@ -28,14 +28,14 @@ import static org.powermock.api.easymock.PowerMock.*;
 /**
  * Test class to demonstrate static, static+final, static+native and
  * static+final+native methods mocking.
- * 
+ *
  * @author Johan Haleby
  * @author Jan Kronquist
  */
 @PrepareForTest( { StaticService.class, StaticHelper.class })
 public class MockStaticExtendsPowerMockTestCaseTest extends PowerMockTestCase {
 
-    @Test(enabled = false)
+    @Test
     public void testMockStatic() throws Exception {
         mockStatic(StaticService.class);
         String expected = "Hello altered World";
@@ -56,7 +56,7 @@ public class MockStaticExtendsPowerMockTestCaseTest extends PowerMockTestCase {
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testMockStaticFinal() throws Exception {
         mockStatic(StaticService.class);
         String expected = "Hello altered World";

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/PartialMockingWithBeforeClassTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/PartialMockingWithBeforeClassTest.java
@@ -39,7 +39,7 @@ public class PartialMockingWithBeforeClassTest extends PowerMockTestCase {
 		tested = createPartialMock(PrivateFinal.class, "sayIt");
 	}
 
-	@Test(enabled = false)
+	@Test
 	public void partialMockingWithMockCreatedInBeforeClassMethod() throws Exception {
 		String expected = "Hello altered World";
 		expectPrivate(tested, "sayIt", "name").andReturn(expected);

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/PrivateFinalTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/PrivateFinalTest.java
@@ -31,7 +31,7 @@ import static org.powermock.api.easymock.PowerMock.expectPrivate;
 @PrepareForTest(PrivateFinal.class)
 public class PrivateFinalTest {
 
-  @Test(enabled = false)
+  @Test
   public void testSay() throws Exception {
     PrivateFinal tested = createPartialMock(PrivateFinal.class, "sayIt");
     String expected = "Hello altered World";
@@ -44,7 +44,7 @@ public class PrivateFinalTest {
     Assert.assertEquals(expected, actual);
   }
 
-  @Test(enabled = false)
+  @Test
   public void testMultiMock() throws Exception {
     PrivateFinal tested1 = createPartialMock(PrivateFinal.class, "sayIt");
     String expected1 = "Hello altered World";
@@ -62,6 +62,4 @@ public class PrivateFinalTest {
     verify(tested2);
     Assert.assertEquals(expected2, actual2);
   }
-
-  
 }

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/SampleServletTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/SampleServletTest.java
@@ -32,7 +32,7 @@ import static org.powermock.api.easymock.PowerMock.*;
 @PrepareForTest(SampleServlet.class)
 public class SampleServletTest {
 
-    @Test(enabled = false)
+    @Test
     public void doGet() throws Exception {
         SampleServlet servlet = new SampleServlet();
 

--- a/tests/easymock/testng-agent/src/test/java/samples/testng/agent/SystemClassUserTest.java
+++ b/tests/easymock/testng-agent/src/test/java/samples/testng/agent/SystemClassUserTest.java
@@ -50,7 +50,7 @@ import static org.testng.AssertJUnit.assertEquals;
 @PrepareForTest( { SystemClassUser.class })
 public class SystemClassUserTest extends PowerMockTestCase {
 
-    @Test(enabled = false)
+    @Test
     public void assertThatMockingOfNonFinalSystemClassesWorks() throws Exception {
         mockStatic(URLEncoder.class);
 
@@ -62,7 +62,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void assertThatMockingOfTheRuntimeSystemClassWorks() throws Exception {
         mockStatic(Runtime.class);
 
@@ -79,7 +79,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void assertThatMockingOfFinalSystemClassesWorks() throws Exception {
         mockStatic(System.class);
 
@@ -92,7 +92,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void assertThatPartialMockingOfFinalSystemClassesWorks() throws Exception {
         mockStaticPartial(System.class, "nanoTime");
 
@@ -107,7 +107,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void assertThatPartialMockingOfFinalSystemClassesWorksForNonVoidMethods() throws Exception {
         mockStaticPartial(System.class, "getProperty");
 
@@ -121,7 +121,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void assertThatMockingOfCollectionsWork() throws Exception {
         List<?> list = new LinkedList<Object>();
         mockStatic(Collections.class);
@@ -136,7 +136,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void assertThatMockingStringWorks() throws Exception {
         mockStatic(String.class);
         final String string = "string";
@@ -153,7 +153,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void mockingStaticVoidMethodWorks() throws Exception {
         mockStatic(Thread.class);
 
@@ -171,7 +171,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void mockingInstanceMethodOfFinalSystemClassWorks() throws Exception {
         URL url = createMock(URL.class);
         URLConnection urlConnection = createMock(URLConnection.class);
@@ -184,7 +184,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void mockingURLWorks() throws Exception {
         URL url = createMock(URL.class);
         URLConnection urlConnectionMock = createMock(URLConnection.class);
@@ -198,7 +198,7 @@ public class SystemClassUserTest extends PowerMockTestCase {
         verifyAll();
     }
 
-    @Test(enabled = false)
+    @Test
     public void mockingInetAddressWorks() throws Exception {
         final InetAddress mock = createMock(InetAddress.class);
         mockStatic(InetAddress.class);


### PR DESCRIPTION
When using the powermock-module-junit4-rule-agent there are `java.lang.VerifyError`s.
For example if you have some project with Spock 1.0 and use use the rule, it works just fine.
As soon as you upgrade to 1.2 or 1.3 which dropped Java 6 support, you get various of these verify errors.

They are all about "Expected stackmap frame at this location.".

I'm no Byte Buddy expert, but from what I have read, the combination of `ClassWriter.COMPUTE_MAXS` with `ClassReader.SKIP_FRAMES` is not the best idea.
`ClassReader.SKIP_FRAMES` will skip reading and visiting stack maps and stack map tables.
The JavaDoc of that attribute says it is for example useful if you use `ClassWriter.COMPUTE_FRAMES` as it recalculates the stackmap frames anyway, so there is no need to parse and visit them.
But like it is currently, they are neither parsed, nor visited, nor computed and thus they are missing when verifying.

As far as I understood there are two ways to handle this, either use `ClassWriter.COMPUTE_FRAMES` and `ClassReader.SKIP_FRAMES`,
as then the frames are not parsed or visited, but recalculated, or do not use both as they are then parsed, visited and in
the case of this visitor just copied.

As the visitor only removes the final modifiers for methods and classes now, I renamed it,
disabled even the MAXS computation and disabled the frame skipping.

From my test it seems to work better with this setting now and also all your tests are green
(except three tests that are red for me even without my changes).

Fixes #1005
Probably fixes #956, #1024, #926, #549, #558, #873, #693, #543

**Update:** also re-enabled the tests that were disabled due to this error in #952
I think the exclusion of TestNG classes in commit e948b49baa7141de7c0e824ad01ba50bb1f05484 was also due to this error and could probably be reverted.

**Work-around:** Use JVM option `-noverify` to disable the verification that complains about the missing stackmap frames.