### PR TITLE
Substitute OpenBeans for java.beans so Android tests work

### DIFF
--- a/powermock-core/build.gradle
+++ b/powermock-core/build.gradle
@@ -1,1 +1,3 @@
-
+dependencies {
+    compile("com.musala.atmosphere:openbeans-jxpath:0.0.1")
+}

--- a/powermock-core/src/main/java/org/powermock/configuration/support/ConfigurationMapper.java
+++ b/powermock-core/src/main/java/org/powermock/configuration/support/ConfigurationMapper.java
@@ -22,9 +22,9 @@ import org.powermock.configuration.Configuration;
 import org.powermock.configuration.ConfigurationType;
 import org.powermock.PowerMockInternalException;
 
-import java.beans.BeanInfo;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
+import com.googlecode.openbeans.BeanInfo;
+import com.googlecode.openbeans.Introspector;
+import com.googlecode.openbeans.PropertyDescriptor;
 import java.util.Properties;
 
 class ConfigurationMapper<T extends Configuration> {


### PR DESCRIPTION
The Android implementation of java.beans does not include everything which gives rise to error messages like this:

```
E/TestRunner: java.lang.NoClassDefFoundError: Failed resolution of: Ljava/beans/Introspector; at
  org.powermock.configuration.support.ConfigurationMapper.map(ConfigurationMapper.java:44) at
  org.powermock.configuration.support.ConfigurationBuilder$ConfigurationCreator.mapConfiguration(ConfigurationBuilder.java:80) at
  ...
```

While it's not clear to me why such abject fanciness is needed in the ConfigurationMapper to take care of a sum total of three properties, it is clear that this change represents a minimum of source changes to get to a working state on Android.

Fixes #1062