### PR TITLE
[Travis CI] Remove deprecated keyword `sudo`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
-# see https://docs.travis-ci.com/user/migrating-from-legacy/ and https://docs.travis-ci.com/user/ci-environment
-sudo: false
-
 # Note that OracleJDK 9 is available for jdk_switcher only on Trusty.
 # https://github.com/travis-ci/travis-ci/issues/7253#issuecomment-283671037
 dist: trusty


### PR DESCRIPTION
<img width="1064" alt="Screen Shot 2020-09-18 at 5 41 28 PM" src="https://user-images.githubusercontent.com/5081226/93610849-40944d80-f9d6-11ea-9e1f-4b847f1a9e8e.png">
