### PR TITLE
Fix Mockito 3 compatibility

### DIFF
--- a/tests/mockito/inline/src/test/java/samples/powermockito/inline/bugs/github793/PowerMockStaticMockingTest.java
+++ b/tests/mockito/inline/src/test/java/samples/powermockito/inline/bugs/github793/PowerMockStaticMockingTest.java
@@ -38,8 +38,9 @@ public class PowerMockStaticMockingTest {
     
     @Test
     public void should_mock_static_method_when_mockito_inline_mock_creator_for_mockito_tests() {
-        
-        assumeTrue("Test make seances only for Mockito 2", MockitoVersion.isMockito2());
+
+        assumeTrue("Test makes sense only for Mockito 2 & 3",
+                MockitoVersion.isMockito2() || MockitoVersion.isMockito3());
     
         PowerMockito.mockStatic(StaticClass.class);
         
@@ -54,8 +55,9 @@ public class PowerMockStaticMockingTest {
     
     @Test
     public void should_verify_static_method_when_mockito_inline_mock_creator_for_mockito_tests() throws Exception {
-    
-        assumeTrue("Test make seances only for Mockito 2", MockitoVersion.isMockito2());
+
+        assumeTrue("Test makes sense only for Mockito 2 & 3",
+                MockitoVersion.isMockito2() || MockitoVersion.isMockito3());
     
         PowerMockito.mockStatic(StaticClass.class);
     
@@ -71,7 +73,6 @@ public class PowerMockStaticMockingTest {
             }
         }).as("Verify exception is thrown")
           .isInstanceOf(NoInteractionsWanted.class);
-        
     }
     
 }

--- a/tests/utils/src/main/java/org/powermock/api/mockito/MockitoVersion.java
+++ b/tests/utils/src/main/java/org/powermock/api/mockito/MockitoVersion.java
@@ -29,6 +29,10 @@ public class MockitoVersion {
     public static boolean isMockito2(){
         return MOCKITO_VERSION.isMockito2_0();
     }
+
+    public static boolean isMockito3(){
+        return MOCKITO_VERSION.isMockito3_0();
+    }
     
     private static final MockitoVersion MOCKITO_VERSION = new MockitoVersion();
     
@@ -58,5 +62,9 @@ public class MockitoVersion {
     
     private boolean isMockito2_0() {
         return version.startsWith("2");
+    }
+
+    private boolean isMockito3_0() {
+        return version.startsWith("3");
     }
 }


### PR DESCRIPTION
The upgrade to Mockito 3 (#1049) introduces build failures. This PR fixes the failures.