### PR TITLE
PowerMockitoStubberImpl.when throws exceptions with methods using arguments with both primitive and wrapped arguments

### DIFF
--- a/powermock-reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
+++ b/powermock-reflect/src/main/java/org/powermock/reflect/internal/WhiteboxImpl.java
@@ -1791,7 +1791,8 @@ public class WhiteboxImpl {
             final Class<?>[] parameterTypes = method.getParameterTypes();
             if (checkIfParameterTypesAreSame(method.isVarArgs(), expectedTypes, parameterTypes)
                         || (!exactParameterTypeMatch && checkIfParameterTypesAreSame(method.isVarArgs(),
-                    convertParameterTypesToPrimitive(expectedTypes), parameterTypes))) {
+                    convertParameterTypesToPrimitive(expectedTypes),
+                    convertParameterTypesToPrimitive(parameterTypes)))) {
                 matchingArgumentTypes.add(method);
             }
         }

--- a/powermock-reflect/src/test/java/org/powermock/reflect/internal/WhiteboxImplTest.java
+++ b/powermock-reflect/src/test/java/org/powermock/reflect/internal/WhiteboxImplTest.java
@@ -17,6 +17,7 @@ package org.powermock.reflect.internal;
 
 import org.junit.Test;
 import org.powermock.reflect.testclasses.Child;
+import org.powermock.reflect.testclasses.ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument;
 import org.powermock.reflect.testclasses.ClassWithOverloadedMethods;
 import org.powermock.reflect.testclasses.ClassWithStandardMethod;
 
@@ -26,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 
@@ -84,4 +86,21 @@ public class WhiteboxImplTest {
 
         assertThat(methodNames).contains("stream");
     }
+
+    @Test
+	public void testGetMethodNotExactParameterTypeMatch() throws NoSuchMethodException {
+		Method[] methods =
+			WhiteboxImpl.getMethods(
+				ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument.class,
+				"methodHavingBothPrimitiveTypeAndWrappedTypeArgument",
+				new Class<?>[]{Integer.class, Integer.class},
+				false
+			);
+		Method method = ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument.class.getMethod(
+				"methodHavingBothPrimitiveTypeAndWrappedTypeArgument",
+				Integer.class,
+				int.class
+		);
+		assertEquals(methods[0], method);
+	}
 }

--- a/powermock-reflect/src/test/java/org/powermock/reflect/internal/WhiteboxImplTest.java
+++ b/powermock-reflect/src/test/java/org/powermock/reflect/internal/WhiteboxImplTest.java
@@ -16,10 +16,7 @@
 package org.powermock.reflect.internal;
 
 import org.junit.Test;
-import org.powermock.reflect.testclasses.Child;
-import org.powermock.reflect.testclasses.ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument;
-import org.powermock.reflect.testclasses.ClassWithOverloadedMethods;
-import org.powermock.reflect.testclasses.ClassWithStandardMethod;
+import org.powermock.reflect.testclasses.*;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -91,13 +88,13 @@ public class WhiteboxImplTest {
 	public void testGetMethodNotExactParameterTypeMatch() throws NoSuchMethodException {
 		Method[] methods =
 			WhiteboxImpl.getMethods(
-				ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument.class,
-				"methodHavingBothPrimitiveTypeAndWrappedTypeArgument",
+				ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArguments.class,
+				"methodHavingBothPrimitiveTypeAndWrappedTypeArguments",
 				new Class<?>[]{Integer.class, Integer.class},
 				false
 			);
-		Method method = ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument.class.getMethod(
-				"methodHavingBothPrimitiveTypeAndWrappedTypeArgument",
+		Method method = ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArguments.class.getMethod(
+				"methodHavingBothPrimitiveTypeAndWrappedTypeArguments",
 				Integer.class,
 				int.class
 		);

--- a/powermock-reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument.java
+++ b/powermock-reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2008 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.powermock.reflect.testclasses;
+
+public class ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument {
+
+    public void methodHavingBothPrimitiveTypeAndWrappedTypeArgument(Integer arg0, int arg1) {
+
+    }
+}

--- a/powermock-reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArguments.java
+++ b/powermock-reflect/src/test/java/org/powermock/reflect/testclasses/ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArguments.java
@@ -15,9 +15,9 @@
  */
 package org.powermock.reflect.testclasses;
 
-public class ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArgument {
+public class ClassWithMethodUsingBothPrimitiveTypeAndWrappedTypeArguments {
 
-    public void methodHavingBothPrimitiveTypeAndWrappedTypeArgument(Integer arg0, int arg1) {
+    public void methodHavingBothPrimitiveTypeAndWrappedTypeArguments(Integer arg0, int arg1) {
 
     }
 }


### PR DESCRIPTION
Example:
```
public class testClass {

    public int testMethod(Integer arg0, int arg1) {
        return 1;
    }
}
```
The following code throws MethodNotFoundException 
```
PowerMockito.doReturn(0).when(testClassInstance, "testMethod", (Integer)0, 0)
```
Stack trace:
```
	at org.powermock.reflect.internal.WhiteboxImpl.getMethods(WhiteboxImpl.java:1800)
	at org.powermock.reflect.internal.WhiteboxImpl.getBestMethodCandidate(WhiteboxImpl.java:1008)
	at org.powermock.reflect.internal.WhiteboxImpl.findMethodOrThrowException(WhiteboxImpl.java:885)
	at org.powermock.reflect.internal.WhiteboxImpl.doInvokeMethod(WhiteboxImpl.java:822)
	at org.powermock.reflect.internal.WhiteboxImpl.invokeMethod(WhiteboxImpl.java:690)
	at org.powermock.reflect.Whitebox.invokeMethod(Whitebox.java:401)
	at org.powermock.api.mockito.internal.expectation.PowerMockitoStubberImpl.when(PowerMockitoStubberImpl.java:105)
```
