### PR TITLE
Remove JCenter repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
         maven {
             url 'https://repo.spring.io/plugins-release'
         }


### PR DESCRIPTION
Reason: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/