### PR TITLE
Compatibility with mockito 4

### DIFF
--- a/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/extension/listener/AnnotationEnabler.java
+++ b/powermock-api/powermock-api-mockito2/src/main/java/org/powermock/api/extension/listener/AnnotationEnabler.java
@@ -82,7 +82,7 @@ public class AnnotationEnabler extends AbstractPowerMockTestListenerBase impleme
                 MockSettings mockSettings = withSettings();
                 Answers answers = mockAnnotation.answer();
                 if (answers != null) {
-                    mockSettings.defaultAnswer(answers.get());
+                    mockSettings.defaultAnswer(answers);
                 }
 
                 Class<?>[] extraInterfaces = mockAnnotation.extraInterfaces();


### PR DESCRIPTION
`Answers.get()` was removed in mockito 4 and was deprecated since mockito 2.1.0

https://github.com/mockito/mockito/blob/release/3.x/src/main/java/org/mockito/Answers.java#L89 states

```
as of 2.1.0 Use the enum-constant directly, instead of this getter. This method will be removed in a future release<br>
E.g. instead of <code>Answers.CALLS_REAL_METHODS.get()</code> use <code>Answers.CALLS_REAL_METHODS</code> .
```